### PR TITLE
Use flexi_logger without textfilter feature to reduce binary size

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,15 +3,6 @@
 version = 3
 
 [[package]]
-name = "aho-corasick"
-version = "0.7.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "ansi_term"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -143,7 +134,6 @@ dependencies = [
  "glob",
  "lazy_static",
  "log",
- "regex",
  "rustversion",
  "thiserror",
  "time",
@@ -535,23 +525,6 @@ checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
 dependencies = [
  "bitflags",
 ]
-
-[[package]]
-name = "regex"
-version = "1.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a11647b6b25ff05a515cb92c365cec08801e83423a235b51e231e1808747286"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-syntax"
-version = "0.6.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 
 [[package]]
 name = "rustversion"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,8 @@ anyhow = "1.0.44"
 assert_matches = "1.5.0"
 clap = { version = "3.1.8", features = ["cargo"] }
 crossterm = { version = "0.23.2", features = ["event-stream"] }
-flexi_logger = "0.22.3"
+# Excluded "textfilter" feature that depends on regex (~0.7 MiB).
+flexi_logger = { version = "0.22.3", default-features = false, features = ["colors"] }
 futures = { version = "0.3.21" }
 indexmap = { version = "1.8.0", features = ["serde"] }
 libc = "0.2.120"


### PR DESCRIPTION
2.0 MiB -> 1.3 MiB on Alpine Linux x86_64 (musl, dynamically linked)