### PR TITLE
Feature: Support config files named "mprocs.yml"

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -84,15 +84,7 @@ fn load_config(matches: &ArgMatches) -> anyhow::Result<Config> {
     return Config::from_path(path);
   }
 
-  {
-    let path = "mprocs.yaml";
-    if Path::new(path).is_file() {
-      return Config::from_path(path);
-    }
-  }
-
-  {
-    let path = "mprocs.json";
+  for path in ["mprocs.yaml", "mprocs.yml", "mprocs.json"] {
     if Path::new(path).is_file() {
       return Config::from_path(path);
     }


### PR DESCRIPTION
Thanks for creating this terminal UI! I was looking for something just like this and found it really helpful.

Do you think it would be reasonable to support `.yml` file extension as well? It's also a very common extension for YAML files, and it's supported by GitHub Actions, Docker Compose, and most editors.