### PR TITLE
Clear terminal and force a full redraw before mproc starts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- Clears the terminal before the first render.
+
 ## 0.5.0 - 2022-06-20
 
 - Add command for scrolling by N lines (`C-e`/`C-y`)

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ With mprocs you can list these command in `mprocs.yaml` and run all of them by
 running `mprocs`. Then you can switch between outputs of running commands and
 interact with them.
 
-It is simmilar to
+It is similar to
 [concurrently](https://github.com/open-cli-tools/concurrently) but _mprocs_
 shows output of each command separately and allows to interact with processes
 (you can even work in _vim_ inside _mprocs_).

--- a/src/app.rs
+++ b/src/app.rs
@@ -94,9 +94,9 @@ impl App {
   }
 
   pub async fn run(mut self) -> anyhow::Result<()> {
-    self.terminal.clear()?;
     enable_raw_mode()?;
     execute!(io::stdout(), EnterAlternateScreen)?;
+    self.terminal.clear()?;
     execute!(io::stdout(), EnableMouseCapture)?;
 
     let (exit_trigger, exit_listener) = triggered::trigger();

--- a/src/app.rs
+++ b/src/app.rs
@@ -93,7 +93,8 @@ impl App {
     Ok(app)
   }
 
-  pub async fn run(self) -> anyhow::Result<()> {
+  pub async fn run(mut self) -> anyhow::Result<()> {
+    self.terminal.clear()?;
     enable_raw_mode()?;
     execute!(io::stdout(), EnterAlternateScreen)?;
     execute!(io::stdout(), EnableMouseCapture)?;


### PR DESCRIPTION
This fixes a bug where if I have my terminal already filled with output (from previous command) and then invoking mprocs contains those outputs in a garbled manner.

While in the currents widgets impelementation, we use use the [Clear widget](https://docs.rs/tui/0.18.0/tui/widgets/struct.Clear.html), but that is not enough. The linked docs recommend instead to use `Terminal::clear`.

With this patch, I can confirm that it fixes the garbled out for me.
