### PR TITLE
Display keybindings which are customized by the user 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - Clears the terminal before the first render.
+- Display keybindings which are customized by the user
 
 ## 0.5.0 - 2022-06-20
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -186,7 +186,7 @@ impl App {
 
           render_procs(layout.procs, f, &mut self.state);
           render_term(layout.term, f, &mut self.state);
-          render_keymap(layout.keymap, f, &mut self.state);
+          render_keymap(layout.keymap, f, &mut self.state, self.keymap.clone());
           render_zoom_tip(layout.zoom_banner, f);
 
           if let Some(modal) = &mut self.state.modal {

--- a/src/event.rs
+++ b/src/event.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::key::Key;
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 #[serde(tag = "c", rename_all = "kebab-case")]
 pub enum AppEvent {
   Batch { cmds: Vec<AppEvent> },

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 
 use crate::{event::AppEvent, key::Key, state::Scope};
 
+#[derive(Debug)]
 pub struct Keymap {
   pub procs: HashMap<Key, AppEvent>,
   pub term: HashMap<Key, AppEvent>,
@@ -21,6 +22,34 @@ impl Keymap {
 
   pub fn bind_t(&mut self, key: Key, event: AppEvent) {
     self.term.insert(key, event);
+  }
+
+  pub fn resolve_key(&self, scope: Scope, app_event: &AppEvent) -> Vec<&Key> {
+    let map = match scope {
+      Scope::Procs => &self.procs,
+      Scope::Term | Scope::TermZoom => &self.term,
+    };
+    let mut vec = Vec::new();
+    for (k, v) in map.iter() {
+      if v == app_event {
+        vec.push(k)
+      }
+    }
+    vec
+  }
+
+  /// Returns non default key if present
+  pub fn non_default_key(
+    &self,
+    scope: Scope,
+    app_event: &AppEvent,
+    default_keys: Vec<&Key>,
+  ) -> Option<&Key> {
+    let keys = self.resolve_key(scope, app_event);
+    keys
+      .into_iter()
+      .filter(|key| !default_keys.contains(key))
+      .next()
   }
 
   pub fn resolve(&self, scope: Scope, key: &Key) -> Option<&AppEvent> {

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -9,6 +9,7 @@ use crate::{
   event::AppEvent,
   key::Key,
   keymap::Keymap,
+  state::Scope,
   yaml_val::{value_to_string, Val},
 };
 
@@ -30,6 +31,17 @@ impl Default for Settings {
 }
 
 impl Settings {
+  pub fn default_keys(&self, scope: Scope, app_event: &AppEvent) -> Vec<&Key> {
+    let map = match scope {
+      Scope::Procs => &self.keymap_procs,
+      Scope::Term | Scope::TermZoom => &self.keymap_term,
+    };
+    map
+      .iter()
+      .filter_map(|(k, v)| if v == app_event { Some(k) } else { None })
+      .collect()
+  }
+
   pub fn merge_from_xdg(&mut self) -> Result<()> {
     let path = self.get_xdg_config_path()?;
     match File::open(path) {

--- a/src/ui_keymap.rs
+++ b/src/ui_keymap.rs
@@ -1,4 +1,4 @@
-use std::io;
+use std::{io, rc::Rc};
 
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use tui::{
@@ -12,6 +12,10 @@ use tui::{
 
 use crate::{
   encode_term::print_key,
+  event::AppEvent,
+  key::Key,
+  keymap::Keymap,
+  settings::Settings,
   state::{Scope, State},
   theme::Theme,
 };
@@ -22,6 +26,7 @@ pub fn render_keymap(
   area: Rect,
   frame: &mut Frame<Backend>,
   state: &mut State,
+  keymap: Rc<Keymap>,
 ) {
   let theme = Theme::default();
 
@@ -32,17 +37,84 @@ pub fn render_keymap(
   frame.render_widget(block, area);
 
   let items = match state.scope {
-    Scope::Procs => vec![
-      (KeyCode::Char('a'), KeyModifiers::CONTROL, "Toggle focus"),
-      (KeyCode::Char('q'), KeyModifiers::NONE, "Quit"),
-      (KeyCode::Char('j'), KeyModifiers::NONE, "Next"),
-      (KeyCode::Char('k'), KeyModifiers::NONE, "Prev"),
-      (KeyCode::Char('s'), KeyModifiers::NONE, "Start"),
-      (KeyCode::Char('x'), KeyModifiers::NONE, "Stop"),
-      (KeyCode::Char('r'), KeyModifiers::NONE, "Restart"),
-    ],
+    Scope::Procs => {
+      let settings = Settings::default();
+      let prev_default = Key::new(KeyCode::Char('j'), KeyModifiers::NONE);
+      let prev = keymap
+        .non_default_key(
+          Scope::Procs,
+          &AppEvent::PrevProc,
+          settings.default_keys(Scope::Procs, &AppEvent::PrevProc),
+        )
+        .unwrap_or(&prev_default);
+      let quit_default = Key::new(KeyCode::Char('q'), KeyModifiers::NONE);
+      let quit = keymap
+        .non_default_key(
+          Scope::Procs,
+          &AppEvent::Quit,
+          settings.default_keys(Scope::Procs, &AppEvent::Quit),
+        )
+        .unwrap_or(&quit_default);
+      let toggle_default = Key::new(KeyCode::Char('a'), KeyModifiers::CONTROL);
+      let toggle = keymap
+        .non_default_key(
+          Scope::Procs,
+          &AppEvent::ToggleFocus,
+          settings.default_keys(Scope::Procs, &AppEvent::ToggleFocus),
+        )
+        .unwrap_or(&toggle_default);
+      let next_default = Key::new(KeyCode::Char('j'), KeyModifiers::NONE);
+      let next = keymap
+        .non_default_key(
+          Scope::Procs,
+          &AppEvent::NextProc,
+          settings.default_keys(Scope::Procs, &AppEvent::NextProc),
+        )
+        .unwrap_or(&next_default);
+      let start_default = Key::new(KeyCode::Char('s'), KeyModifiers::NONE);
+      let start = keymap
+        .non_default_key(
+          Scope::Procs,
+          &AppEvent::StartProc,
+          settings.default_keys(Scope::Procs, &AppEvent::StartProc),
+        )
+        .unwrap_or(&start_default);
+      let stop_default = Key::new(KeyCode::Char('x'), KeyModifiers::NONE);
+      let stop = keymap
+        .non_default_key(
+          Scope::Procs,
+          &AppEvent::TermProc,
+          settings.default_keys(Scope::Procs, &AppEvent::TermProc),
+        )
+        .unwrap_or(&stop_default);
+      let restart_default = Key::new(KeyCode::Char('r'), KeyModifiers::NONE);
+      let restart = keymap
+        .non_default_key(
+          Scope::Procs,
+          &AppEvent::RestartProc,
+          settings.default_keys(Scope::Procs, &AppEvent::RestartProc),
+        )
+        .unwrap_or(&restart_default);
+      vec![
+        (*toggle.code(), *toggle.mods(), "Toggle focus"),
+        (*quit.code(), *quit.mods(), "Quit"),
+        (*next.code(), *next.mods(), "Next"),
+        (*prev.code(), *prev.mods(), "Prev"),
+        (*start.code(), *start.mods(), "Start"),
+        (*stop.code(), *stop.mods(), "Stop"),
+        (*restart.code(), *restart.mods(), "Restart"),
+      ]
+    }
     Scope::Term => {
-      vec![(KeyCode::Char('a'), KeyModifiers::CONTROL, "Toggle focus")]
+      let toggle_default = Key::new(KeyCode::Char('a'), KeyModifiers::CONTROL);
+      let toggle = keymap
+        .non_default_key(
+          Scope::Term,
+          &AppEvent::ToggleFocus,
+          Settings::default().default_keys(Scope::Term, &AppEvent::ToggleFocus),
+        )
+        .unwrap_or(&toggle_default);
+      vec![(*toggle.code(), *toggle.mods(), "Toggle focus")]
     }
     Scope::TermZoom => Vec::new(),
   };


### PR DESCRIPTION
In the help area in the TUI, display the keybindings that are customized by the user explicitly.

This will fix https://github.com/pvolok/mprocs/issues/35#issuecomment-1162722021