### PR TITLE
Update installation command for Scoop in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ cargo install mprocs
 ### scoop (Windows)
 
 ```sh
-scoop install https://raw.githubusercontent.com/pvolok/mprocs/master/scoop/mprocs.json
+scoop install mprocs
 ```
 
 ### AUR (Arch Linux)


### PR DESCRIPTION
mprocs is now in the main bucket (package repository) of Scoop and so a simpler installation command can be used.

Relevant PR here: https://github.com/ScoopInstaller/Main/pull/3713