### PR TITLE
Refer to crate with crate::

### DIFF
--- a/vendor/pty/src/cmdbuilder.rs
+++ b/vendor/pty/src/cmdbuilder.rs
@@ -206,7 +206,7 @@ impl CommandBuilder {
 
   #[cfg(not(windows))]
   pub fn from_shell(shell: &str) -> Self {
-    portable_pty::CommandBuilder::from_argv(vec![
+    crate::CommandBuilder::from_argv(vec![
       "/bin/sh".into(),
       "-c".into(),
       shell.into(),


### PR DESCRIPTION
This is the current output when trying to compile on linux:

```
error[E0433]: failed to resolve: use of undeclared crate or module `portable_pty`
   --> vendor/pty/src/cmdbuilder.rs:209:19
    |
209 |     portable_pty::CommandBuilder::from_argv(vec![
    |                   ^^^^^^^^^^^^^^ not found in `portable_pty`
    |
help: consider importing this struct
    |
2   | use crate::CommandBuilder;
    |
help: if you import `CommandBuilder`, refer to it directly
    |
209 -     portable_pty::CommandBuilder::from_argv(vec![
209 +     CommandBuilder::from_argv(vec![
    |
```