### PR TITLE
Accept JSON file extension

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -221,13 +221,13 @@ fn read_value(path: &str) -> Result<Value> {
     .extension()
     .map_or_else(|| "".to_string(), |ext| ext.to_string_lossy().to_string());
   let value: Value = match ext.as_str() {
-    "yaml" | "yml" => serde_yaml::from_reader(reader)?,
+    "yaml" | "yml" | "json" => serde_yaml::from_reader(reader)?,
     "lua" => {
       let mut buf = String::new();
       reader.read_to_string(&mut buf)?;
       load_lua_config(path, &buf)?
     }
-    _ => bail!("Supported config extensions: lua, yaml, yml."),
+    _ => bail!("Supported config extensions: lua, yaml, yml, json."),
   };
   Ok(value)
 }


### PR DESCRIPTION
In `load_config_value`, JSON config is automatically loaded from mprocs.json but `read_value` doesn't accept the file extension. Since YAML is a strict superset of JSON we can pass it to the same reader.