### PR TITLE
Use `killpg` instead of `kill` to ensure the whole process group is killed

### DIFF
--- a/src/proc.rs
+++ b/src/proc.rs
@@ -316,7 +316,7 @@ impl Proc {
   #[cfg(not(windows))]
   fn send_signal(&mut self, sig: libc::c_int) {
     if let ProcState::Some(inst) = &self.inst {
-      unsafe { libc::kill(inst.pid as i32, sig) };
+      unsafe { libc::killpg(inst.pid as i32, sig) };
     }
   }
 


### PR DESCRIPTION
I've been running into an issue where some processes that I run inside mprocs don't get killed properly, regardless of what the `stop` config is set to. One example is Consul, like in this config:

```yml
procs:
  Consul:
    shell: "consul agent --data-dir tmp"
```

I noticed that [this line](https://github.com/pvolok/mprocs/blob/03b820c91a33767b73a135fa5caec0182187c1ef/vendor/pty/src/unix.rs#L222) already creates a session and process group when launching a child process, but the way the signal to terminate the process is sent seems to be insufficient, killing only a single process instead of the whole group. I've replaced the `libc::kill` call with `libc::killpg`, which makes using mprocs with programs like consul possible.