### PR TITLE
Add option to start processes after a delay

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,8 @@ settings the _global_.
   - **add_path**: _string|array<string>_ - Add entries to the _PATH_
     environment variable.
   - **autostart**: _bool_ - Start process when mprocs starts. Default: _true_.
+  - **startup_delay**: _float_ - Delay in seconds before starting the process.
+    Default: _0_.
   - **stop**: _"SIGINT"|"SIGTERM"|"SIGKILL"|{send-keys:
     array<key>}|"hard-kill"_ -
     A way to stop a process (using `x` key or when quitting mprocs).

--- a/src/app.rs
+++ b/src/app.rs
@@ -552,6 +552,7 @@ impl App {
             cwd: None,
             env: None,
             autostart: true,
+            startup_delay: std::time::Duration::ZERO,
             stop: StopSignal::default(),
             mouse_scroll_speed: self.config.mouse_scroll_speed,
           },

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,4 @@
-use std::{ffi::OsString, path::PathBuf, str::FromStr};
+use std::{ffi::OsString, path::PathBuf, str::FromStr, time::Duration};
 
 use anyhow::{bail, Result};
 use indexmap::IndexMap;
@@ -88,6 +88,7 @@ pub struct ProcConfig {
   pub cwd: Option<OsString>,
   pub env: Option<IndexMap<String, Option<String>>>,
   pub autostart: bool,
+  pub startup_delay: Duration,
 
   pub stop: StopSignal,
 
@@ -114,6 +115,7 @@ impl ProcConfig {
         env: None,
         autostart: true,
         stop: StopSignal::default(),
+        startup_delay: Duration::ZERO,
 
         mouse_scroll_speed,
       })),
@@ -131,6 +133,7 @@ impl ProcConfig {
           env: None,
           autostart: true,
           stop: StopSignal::default(),
+          startup_delay: Duration::ZERO,
           mouse_scroll_speed,
         }))
       }
@@ -238,6 +241,11 @@ impl ProcConfig {
           .get(&Value::from("autostart"))
           .map_or(Ok(true), |v| v.as_bool())?;
 
+        let startup_delay = map
+          .get(&Value::from("startup_delay"))
+          .map_or(Ok(0.0), |v| v.as_f64())
+          .map(Duration::from_secs_f64)?;
+
         let stop_signal = if let Some(val) = map.get(&Value::from("stop")) {
           serde_yaml::from_value(val.raw().clone())?
         } else {
@@ -250,6 +258,7 @@ impl ProcConfig {
           cwd,
           env,
           autostart,
+          startup_delay,
           stop: stop_signal,
           mouse_scroll_speed,
         }))

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,7 +26,7 @@ mod ui_zoom_tip;
 mod widgets;
 mod yaml_val;
 
-use std::{io::Read, path::Path};
+use std::{io::Read, path::Path, time::Duration};
 
 use anyhow::{bail, Result};
 use app::server_main;
@@ -144,6 +144,7 @@ async fn run_app() -> anyhow::Result<()> {
           env: None,
           cwd: None,
           autostart: true,
+          startup_delay: Duration::ZERO,
           stop: StopSignal::default(),
           mouse_scroll_speed: settings.mouse_scroll_speed,
         })

--- a/src/package_json.rs
+++ b/src/package_json.rs
@@ -1,4 +1,4 @@
-use std::{fs::File, io::BufReader};
+use std::{fs::File, io::BufReader, time::Duration};
 
 use anyhow::Result;
 use indexmap::IndexMap;
@@ -45,6 +45,7 @@ pub fn load_npm_procs(settings: &Settings) -> Result<Vec<ProcConfig>> {
     cwd: None,
     env: Some(env.clone()),
     autostart: false,
+    startup_delay: Duration::ZERO,
 
     stop: StopSignal::default(),
     mouse_scroll_speed: settings.mouse_scroll_speed,

--- a/src/yaml_val.rs
+++ b/src/yaml_val.rs
@@ -94,6 +94,12 @@ impl<'a> Val<'a> {
     })
   }
 
+  pub fn as_f64(&self) -> anyhow::Result<f64> {
+    self.0.as_f64().ok_or_else(|| {
+      anyhow::format_err!("Expected number at {}", self.1.to_string())
+    })
+  }
+
   pub fn as_usize(&self) -> anyhow::Result<usize> {
     self
       .0


### PR DESCRIPTION
I've been using mprocs for the last couple months, and one feature that I've been missing is the option to add a delay to when processes start up.

So far I've been working around it using a shell command like `sleep 5 && ...`, but this has the major downside of also adding a delay every time I restart a process. Adding a `startup_delay` option that only takes effect when initially starting mprocs fixes that issue, so the delay isn't added when restarting processes.