### PR TITLE
feat: show exit code

### DIFF
--- a/src/proc/handle.rs
+++ b/src/proc/handle.rs
@@ -7,6 +7,7 @@ pub struct ProcHandle {
   id: usize,
   name: String,
   is_up: bool,
+  exit_code: Option<u32>,
 
   pub to_restart: bool,
   changed: bool,
@@ -20,6 +21,7 @@ impl ProcHandle {
       id: proc.id,
       name,
       is_up: false,
+      exit_code: None,
       to_restart: false,
       changed: false,
       proc,
@@ -36,6 +38,10 @@ impl ProcHandle {
 
   pub fn id(&self) -> usize {
     self.id
+  }
+
+  pub fn exit_code(&self) -> Option<u32> {
+    self.exit_code
   }
 
   pub fn lock_view(&self) -> ProcViewFrame {
@@ -78,8 +84,9 @@ impl ProcHandle {
           self.changed = true;
         }
       }
-      ProcEvent::Stopped => {
+      ProcEvent::Stopped(exit_code) => {
         self.is_up = false;
+        self.exit_code = Some(exit_code);
         if self.to_restart {
           self.to_restart = false;
           self.send(ProcCmd::Start);

--- a/src/proc/mod.rs
+++ b/src/proc/mod.rs
@@ -111,9 +111,12 @@ impl Inst {
       let running = running.clone();
       spawn(move || {
         // Block until program exits
-        let _status = child.wait();
+        let exit_code = match child.wait() {
+          Ok(status) => status.exit_code(),
+          Err(_e) => 1,
+        };
         running.store(false, Ordering::Relaxed);
-        let _result = tx.send((id, ProcEvent::Stopped));
+        let _result = tx.send((id, ProcEvent::Stopped(exit_code)));
       });
     }
 

--- a/src/proc/msg.rs
+++ b/src/proc/msg.rs
@@ -26,6 +26,6 @@ pub enum ProcCmd {
 #[derive(Debug)]
 pub enum ProcEvent {
   Render,
-  Stopped,
+  Stopped(u32),
   Started,
 }

--- a/src/ui_procs.rs
+++ b/src/ui_procs.rs
@@ -71,7 +71,11 @@ fn create_proc_item<'a>(
         .add_modifier(Modifier::BOLD),
     )
   } else {
-    Span::styled(" DOWN ", Style::default().fg(Color::LightRed))
+    let status = match proc_handle.exit_code() {
+      Some(exit_code) => format!(" DOWN ({})", exit_code),
+      None => " DOWN ".to_string(),
+    };
+    Span::styled(status, Style::default().fg(Color::LightRed))
   };
 
   let mark = if is_cur {


### PR DESCRIPTION
![image](https://github.com/pvolok/mprocs/assets/9079960/f9020b73-ca5c-4527-880c-0ffc8cd6d76e)

Implementation:
- Proc handle keeps track of exit code
- Stopped event now passes exit code too, ProcHandle stores this.
- in UI we show exit code if the process actually started and exited, else previous behaviour. 


alternative to https://github.com/pvolok/mprocs/pull/118
closes https://github.com/pvolok/mprocs/issues/116


P.S. - I know Rust about as much as that bot, so feel free to close the PR if it doesn't meet the expectation :smile: 

I love mprocs btw, thanks for this amazing tool!