### PR TITLE
feat: Auto-restart processes

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ settings the _global_.
   - **add_path**: _string|array<string>_ - Add entries to the _PATH_
     environment variable.
   - **autostart**: _bool_ - Start process when mprocs starts. Default: _true_.
+  - **autorestart**: _bool_ - Restart process when it exits. Default: false. Note: If process exits within 1 second of starting, it will not be restarted.
   - **stop**: _"SIGINT"|"SIGTERM"|"SIGKILL"|{send-keys:
     array<key>}|"hard-kill"_ -
     A way to stop a process (using `x` key or when quitting mprocs).

--- a/src/app.rs
+++ b/src/app.rs
@@ -567,6 +567,7 @@ impl App {
             cwd: None,
             env: None,
             autostart: true,
+            autorestart: false,
             stop: StopSignal::default(),
             mouse_scroll_speed: self.config.mouse_scroll_speed,
           },

--- a/src/config.rs
+++ b/src/config.rs
@@ -88,6 +88,7 @@ pub struct ProcConfig {
   pub cwd: Option<OsString>,
   pub env: Option<IndexMap<String, Option<String>>>,
   pub autostart: bool,
+  pub autorestart: bool,
 
   pub stop: StopSignal,
 
@@ -113,6 +114,7 @@ impl ProcConfig {
         cwd: None,
         env: None,
         autostart: true,
+        autorestart: false,
         stop: StopSignal::default(),
 
         mouse_scroll_speed,
@@ -130,6 +132,7 @@ impl ProcConfig {
           cwd: None,
           env: None,
           autostart: true,
+          autorestart: false,
           stop: StopSignal::default(),
           mouse_scroll_speed,
         }))
@@ -238,6 +241,10 @@ impl ProcConfig {
           .get(&Value::from("autostart"))
           .map_or(Ok(true), |v| v.as_bool())?;
 
+        let autorestart = map
+          .get(&Value::from("autorestart"))
+          .map_or(Ok(false), |v| v.as_bool())?;
+
         let stop_signal = if let Some(val) = map.get(&Value::from("stop")) {
           serde_yaml::from_value(val.raw().clone())?
         } else {
@@ -250,6 +257,7 @@ impl ProcConfig {
           cwd,
           env,
           autostart,
+          autorestart,
           stop: stop_signal,
           mouse_scroll_speed,
         }))

--- a/src/main.rs
+++ b/src/main.rs
@@ -144,6 +144,7 @@ async fn run_app() -> anyhow::Result<()> {
           env: None,
           cwd: None,
           autostart: true,
+          autorestart: false,
           stop: StopSignal::default(),
           mouse_scroll_speed: settings.mouse_scroll_speed,
         })

--- a/src/package_json.rs
+++ b/src/package_json.rs
@@ -45,6 +45,7 @@ pub fn load_npm_procs(settings: &Settings) -> Result<Vec<ProcConfig>> {
     cwd: None,
     env: Some(env.clone()),
     autostart: false,
+    autorestart: false,
 
     stop: StopSignal::default(),
     mouse_scroll_speed: settings.mouse_scroll_speed,

--- a/src/proc/mod.rs
+++ b/src/proc/mod.rs
@@ -202,7 +202,7 @@ pub fn create_proc(
   size: Rect,
 ) -> ProcHandle {
   let proc = Proc::new(cfg, tx, size);
-  ProcHandle::from_proc(name, proc)
+  ProcHandle::from_proc(name, proc, cfg.autorestart)
 }
 
 impl Proc {


### PR DESCRIPTION
Often I need to restart some process (like Redis), this ends up killing dependent processes like background workers and listeners. This PR adds a mechanism to restart them if they exit.

As preliminary safety mechanism, processes won't be restarted if they exit in 1 second from last start time. This is at present hard-coded in code, I can make it configurable if it seems important to control it. We should probably also backoff for a short period?

New boolean flag `autorestart` is introduced on proc config to accommodate this configuration.

Example config:
```
procs:
  sleep2:
    shell: "sleep 2"
    autorestart: true

  sleep0.5:
    shell: "sleep 0.5"
    autorestart: true # This will not get restarted because of fast exit
```

![image](https://github.com/pvolok/mprocs/assets/9079960/a54df2eb-b60a-4435-880c-c6e271a317e7)


Closes https://github.com/pvolok/mprocs/issues/113
Closes https://github.com/pvolok/mprocs/issues/68