### PR TITLE
Update README.md for Windows config

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ the [Remote control](#remote-control) section.
 There are three keymap levels:
 
 - Default keymaps
-- `~/.config/mprocs/mprocs.yaml` (`~\AppData\Roaming\mprocs\mprocs.yaml` on Windows)
+- `~/.config/mprocs/mprocs.yaml` (or `~\AppData\Roaming\mprocs\mprocs.yaml` on Windows)
 - `./mprocs.yaml` (can be overridden by the _-c/--config_ cli arg)
 
 Lower levers override bindings from previous levels. Key bindings from previous

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ procs:
 
 There are two kinds of configs: global and local. _Global_ config is loaded
 from `~/.config/mprocs/mprocs.yaml` (or
-`C:\Users\Alice\AppData\Roaming\mprocs\mprocs.yaml` on Windows). _Local_ config
+`~\AppData\Roaming\mprocs\mprocs.yaml` on Windows). _Local_ config
 is loaded from `mprocs.yaml` from current directory (or set via cli argument:
 `mprocs --config ./cfg/mprocs.yaml`). Settings in the _local_ config override
 settings the _global_.
@@ -175,7 +175,7 @@ the [Remote control](#remote-control) section.
 There are three keymap levels:
 
 - Default keymaps
-- `~/.config/mprocs/mprocs.yaml`
+- `~/.config/mprocs/mprocs.yaml` (`~\AppData\Roaming\mprocs\mprocs.yaml` on Windows)
 - `./mprocs.yaml` (can be overridden by the _-c/--config_ cli arg)
 
 Lower levers override bindings from previous levels. Key bindings from previous


### PR DESCRIPTION
There was a part of the docs that didn't have the proper path for Windows users. It looked like it was using the Linux config path.

Also updated paths to use tilde (`~`) instead of absolute paths to be more consistent with individual users. Opted for his rather than dealing with `%APPDATA%` and `$Env:APPDATA` which can be confusing for some people.