### PR TITLE
use blue for exit code 0

### DIFF
--- a/src/ui_procs.rs
+++ b/src/ui_procs.rs
@@ -68,11 +68,16 @@ fn create_proc_item<'a>(
         .add_modifier(Modifier::BOLD),
     )
   } else {
-    let status = match proc_handle.exit_code() {
-      Some(exit_code) => format!(" DOWN ({})", exit_code),
-      None => " DOWN ".to_string(),
-    };
-    Span::styled(status, Style::default().fg(Color::LightRed))
+    match proc_handle.exit_code() {
+      Some(0) => {
+        Span::styled(" DOWN (0)", Style::default().fg(Color::LightBlue))
+      }
+      Some(exit_code) => Span::styled(
+        format!(" DOWN ({})", exit_code),
+        Style::default().fg(Color::LightRed),
+      ),
+      None => Span::styled(" DOWN ", Style::default().fg(Color::LightRed)),
+    }
   };
 
   let mark = if is_cur {


### PR DESCRIPTION
I have a few init scripts I run as part of mprocs and found the red color a little misleading, so I thought it would be nice to use a different color for exit code 0 specifically.

I also considered change the status message to "DONE" or similar, but wasn't sure your opinions on that.

Looks like this:
![image](https://github.com/user-attachments/assets/d8d70a53-ca0c-4aca-bfbe-4e08c06baafb)


(This is my first time writing Rust and very happy for any/all feedback!)