### PR TITLE
Add key binding for toggling keymap

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -663,6 +663,11 @@ impl App {
         loop_action.render();
       }
 
+      AppEvent::ToggleKeymapWindow => {
+        self.state.toggle_keymap_window();
+        loop_action.render();
+      }
+
       AppEvent::SendKey { key } => {
         if let Some(proc) = self.state.get_current_proc_mut() {
           proc.send(ProcCmd::SendKey(key.clone()));
@@ -691,6 +696,7 @@ impl App {
     AppLayout::new(
       Rect::new(0, 0, size.width, size.height),
       self.state.scope.is_zoomed(),
+      self.state.hide_keymap_window,
       &self.config,
     )
   }
@@ -704,8 +710,8 @@ struct AppLayout {
 }
 
 impl AppLayout {
-  pub fn new(area: Rect, zoom: bool, config: &Config) -> Self {
-    let keymap_h = if zoom || config.hide_keymap_window {
+  pub fn new(area: Rect, zoom: bool, hide_keymap_window: bool, config: &Config) -> Self {
+    let keymap_h = if zoom || hide_keymap_window {
       0
     } else {
       3
@@ -999,6 +1005,7 @@ pub async fn kernel_main(
     scope: Scope::Procs,
     procs: Vec::new(),
     selected: 0,
+    hide_keymap_window: config.hide_keymap_window,
 
     quitting: false,
   };

--- a/src/app.rs
+++ b/src/app.rs
@@ -253,17 +253,20 @@ impl App {
       let size = client.size();
       if self.screen_size != size {
         self.screen_size = size;
-
-        let area = self.get_layout().term_area();
-        for proc_handle in &mut self.state.procs {
-          proc_handle.send(ProcCmd::Resize {
-            x: area.x,
-            y: area.y,
-            w: area.width,
-            h: area.height,
-          });
-        }
+        self.sync_proc_handle_size();
       }
+    }
+  }
+
+  fn sync_proc_handle_size(&mut self) {
+    let area = self.get_layout().term_area();
+    for proc_handle in &mut self.state.procs {
+      proc_handle.send(ProcCmd::Resize {
+        x: area.x,
+        y: area.y,
+        w: area.width,
+        h: area.height,
+      });
     }
   }
 
@@ -665,6 +668,7 @@ impl App {
 
       AppEvent::ToggleKeymapWindow => {
         self.state.toggle_keymap_window();
+        self.sync_proc_handle_size();
         loop_action.render();
       }
 
@@ -710,12 +714,13 @@ struct AppLayout {
 }
 
 impl AppLayout {
-  pub fn new(area: Rect, zoom: bool, hide_keymap_window: bool, config: &Config) -> Self {
-    let keymap_h = if zoom || hide_keymap_window {
-      0
-    } else {
-      3
-    };
+  pub fn new(
+    area: Rect,
+    zoom: bool,
+    hide_keymap_window: bool,
+    config: &Config,
+  ) -> Self {
+    let keymap_h = if zoom || hide_keymap_window { 0 } else { 3 };
     let procs_w = if zoom {
       0
     } else {

--- a/src/event.rs
+++ b/src/event.rs
@@ -48,6 +48,7 @@ pub enum AppEvent {
   CopyModeMove { dir: CopyMove },
   CopyModeEnd,
   CopyModeCopy,
+  ToggleKeymapWindow,
 
   SendKey { key: Key },
 }
@@ -98,6 +99,7 @@ impl AppEvent {
       }
       AppEvent::CopyModeEnd => "Select end position".to_string(),
       AppEvent::CopyModeCopy => "Copy selected text".to_string(),
+      AppEvent::ToggleKeymapWindow => "Toggle help".to_string(),
       AppEvent::SendKey { key } => format!("Send {} key", key.to_string()),
     }
   }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -249,6 +249,11 @@ impl Settings {
     );
 
     s.keymap_add_p(
+      Key::new(KeyCode::Char('h'), KeyModifiers::NONE),
+      AppEvent::ToggleKeymapWindow,
+    );
+
+    s.keymap_add_p(
       Key::new(KeyCode::Char('v'), KeyModifiers::NONE),
       AppEvent::CopyModeEnter,
     );

--- a/src/state.rs
+++ b/src/state.rs
@@ -35,6 +35,7 @@ pub struct State {
   pub scope: Scope,
   pub procs: Vec<ProcHandle>,
   pub selected: usize,
+  pub hide_keymap_window: bool,
 
   pub quitting: bool,
 }
@@ -74,5 +75,9 @@ impl State {
 
   pub fn all_procs_down(&self) -> bool {
     self.procs.iter().all(|p| !p.is_up())
+  }
+
+  pub fn toggle_keymap_window(&mut self) {
+    self.hide_keymap_window = !self.hide_keymap_window;
   }
 }

--- a/src/ui_keymap.rs
+++ b/src/ui_keymap.rs
@@ -38,6 +38,7 @@ pub fn render_keymap(
       AppEvent::StartProc,
       AppEvent::TermProc,
       AppEvent::RestartProc,
+      AppEvent::ToggleKeymapWindow,
     ],
     KeymapGroup::Term => vec![AppEvent::ToggleFocus],
     KeymapGroup::Copy => vec![


### PR DESCRIPTION
## Problem

They keymap is super handy, but once you're acquainted with it, it just isn't needed any longer.

## Proposed solution

This PR adds the ability to instantly free up that real estate by toggling the keymap (aka "help") with "h":

![2025-01-09 01 21 24](https://github.com/user-attachments/assets/e58b1107-dec0-4288-9a0a-d556992be62f)

I'm aware that the config option `hide_keymap_window` exists, but it took me extra digging to find it!

As multiple engineers on my team now use `mprocs`, and we'll be onboarding new ones who haven't used `mprocs` before, we can't force-hide the useful keymap for everyone. Then, people definitely are unlikely to find out about `hide_keymap_window` on their own - I looked deliberately as I'm partial to mprocs, and it still took me extra effort.

Hence `<h: Toggle help>` as part of the help UI!