### PR TITLE
Add --title argument to set a custom title for the processes pane

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -882,7 +882,7 @@ impl ClientHandle {
     &mut self,
     state: &mut State,
     layout: &AppLayout,
-    _config: &Config,
+    config: &Config,
     keymap: &Keymap,
     modal: &mut Option<Box<dyn Modal>>,
     rest: &mut [ClientHandle],
@@ -890,7 +890,7 @@ impl ClientHandle {
     self.terminal.draw(|f| {
       let mut cursor_style = self.cursor_style;
 
-      render_procs(layout.procs, f, state);
+      render_procs(layout.procs, f, state, &config);
       render_term(layout.term, f, state, &mut cursor_style);
       render_keymap(layout.keymap, f, state, keymap);
       render_zoom_tip(layout.zoom_banner, f, keymap);

--- a/src/config.rs
+++ b/src/config.rs
@@ -12,6 +12,8 @@ use crate::{
   yaml_val::{value_to_string, Val},
 };
 
+const DEFAULT_PROCESSES_TITLE: &'static str = "Processes";
+
 pub struct ConfigContext {
   pub path: PathBuf,
 }
@@ -23,6 +25,7 @@ pub struct Config {
   pub mouse_scroll_speed: usize,
   pub scrollback_len: usize,
   pub proc_list_width: usize,
+  pub title: String,
 }
 
 impl Config {
@@ -62,6 +65,14 @@ impl Config {
       None
     };
 
+    let title = if let Some(title) = config.get(&Value::from("title")) {
+      title.as_str()?.to_string()
+    } else if let Some(title) = &settings.title {
+      title.clone()
+    } else {
+      DEFAULT_PROCESSES_TITLE.to_string()
+    };
+
     let config = Config {
       procs,
       server,
@@ -69,6 +80,7 @@ impl Config {
       mouse_scroll_speed: settings.mouse_scroll_speed,
       scrollback_len: settings.scrollback_len,
       proc_list_width: settings.proc_list_width,
+      title,
     };
 
     Ok(config)
@@ -82,6 +94,7 @@ impl Config {
       mouse_scroll_speed: settings.mouse_scroll_speed,
       scrollback_len: settings.scrollback_len,
       proc_list_width: settings.proc_list_width,
+      title: DEFAULT_PROCESSES_TITLE.to_string(),
     }
   }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -12,8 +12,6 @@ use crate::{
   yaml_val::{value_to_string, Val},
 };
 
-const DEFAULT_PROCESSES_TITLE: &'static str = "Processes";
-
 pub struct ConfigContext {
   pub path: PathBuf,
 }
@@ -25,7 +23,7 @@ pub struct Config {
   pub mouse_scroll_speed: usize,
   pub scrollback_len: usize,
   pub proc_list_width: usize,
-  pub title: String,
+  pub proc_list_title: String,
 }
 
 impl Config {
@@ -65,13 +63,12 @@ impl Config {
       None
     };
 
-    let title = if let Some(title) = config.get(&Value::from("title")) {
-      title.as_str()?.to_string()
-    } else if let Some(title) = &settings.title {
-      title.clone()
-    } else {
-      DEFAULT_PROCESSES_TITLE.to_string()
-    };
+    let proc_list_title =
+      if let Some(title) = config.get(&Value::from("proc_list_title")) {
+        title.as_str()?.to_string()
+      } else {
+        settings.proc_list_title.clone()
+      };
 
     let config = Config {
       procs,
@@ -80,7 +77,7 @@ impl Config {
       mouse_scroll_speed: settings.mouse_scroll_speed,
       scrollback_len: settings.scrollback_len,
       proc_list_width: settings.proc_list_width,
-      title,
+      proc_list_title,
     };
 
     Ok(config)
@@ -94,7 +91,7 @@ impl Config {
       mouse_scroll_speed: settings.mouse_scroll_speed,
       scrollback_len: settings.scrollback_len,
       proc_list_width: settings.proc_list_width,
-      title: DEFAULT_PROCESSES_TITLE.to_string(),
+      proc_list_title: settings.proc_list_title.clone(),
     }
   }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,9 +38,9 @@ use config_lua::load_lua_config;
 use ctl::run_ctl;
 use flexi_logger::{FileSpec, LoggerHandle};
 use host::{receiver::MsgReceiver, sender::MsgSender};
+use just::load_just_procs;
 use keymap::Keymap;
 use package_json::load_npm_procs;
-use just::load_just_procs;
 use proc::StopSignal;
 use serde_yaml::Value;
 use settings::Settings;
@@ -89,6 +89,7 @@ async fn run_app() -> anyhow::Result<()> {
     .arg(arg!(-c --config [PATH] "Config path [default: mprocs.yaml]"))
     .arg(arg!(-s --server [PATH] "Remote control server address. Example: 127.0.0.1:4050."))
     .arg(arg!(--ctl [YAML] "Send yaml/json encoded command to running mprocs"))
+    .arg(arg!(--title [TITLE] "Title for the processes pane"))
     .arg(arg!(--names [NAMES] "Names for processes provided by cli arguments. Separated by comma."))
     .arg(arg!(--npm "Run scripts from package.json. Scripts are not started by default."))
     .arg(arg!(--just "Run recipes from justfile. Recipes are not started by default. Requires just to be installed."))
@@ -129,6 +130,10 @@ async fn run_app() -> anyhow::Result<()> {
 
     if let Some(ctl_arg) = matches.get_one::<String>("ctl") {
       return run_ctl(ctl_arg, &config).await;
+    }
+
+    if let Some(title) = matches.get_one::<String>("title") {
+      config.title = title.to_string();
     }
 
     if let Some(cmds) = matches.get_many::<String>("COMMANDS") {

--- a/src/main.rs
+++ b/src/main.rs
@@ -89,7 +89,7 @@ async fn run_app() -> anyhow::Result<()> {
     .arg(arg!(-c --config [PATH] "Config path [default: mprocs.yaml]"))
     .arg(arg!(-s --server [PATH] "Remote control server address. Example: 127.0.0.1:4050."))
     .arg(arg!(--ctl [YAML] "Send yaml/json encoded command to running mprocs"))
-    .arg(arg!(--title [TITLE] "Title for the processes pane"))
+    .arg(arg!(--"proc-list-title" [TITLE] "Title for the processes pane"))
     .arg(arg!(--names [NAMES] "Names for processes provided by cli arguments. Separated by comma."))
     .arg(arg!(--npm "Run scripts from package.json. Scripts are not started by default."))
     .arg(arg!(--just "Run recipes from justfile. Recipes are not started by default. Requires just to be installed."))
@@ -132,8 +132,8 @@ async fn run_app() -> anyhow::Result<()> {
       return run_ctl(ctl_arg, &config).await;
     }
 
-    if let Some(title) = matches.get_one::<String>("title") {
-      config.title = title.to_string();
+    if let Some(title) = matches.get_one::<String>("proc-list-title") {
+      config.proc_list_title = title.to_string();
     }
 
     if let Some(cmds) = matches.get_many::<String>("COMMANDS") {

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -21,7 +21,7 @@ pub struct Settings {
   pub mouse_scroll_speed: usize,
   pub scrollback_len: usize,
   pub proc_list_width: usize,
-  pub title: Option<String>,
+  pub proc_list_title: String,
 }
 
 impl Default for Settings {
@@ -34,7 +34,7 @@ impl Default for Settings {
       mouse_scroll_speed: 5,
       scrollback_len: 1000,
       proc_list_width: 30,
-      title: None,
+      proc_list_title: "Processes".to_string(),
     };
     settings.add_defaults();
     settings
@@ -138,6 +138,10 @@ impl Settings {
 
     if let Some(scrollback) = obj.get(&Value::from("scrollback")) {
       self.scrollback_len = scrollback.as_usize()?;
+    }
+
+    if let Some(proc_list_title) = obj.get(&Value::from("proc_list_title")) {
+      self.proc_list_title = proc_list_title.as_str()?.to_string().into();
     }
 
     if let Some(proc_list_width) = obj.get(&Value::from("proc_list_width")) {

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -21,6 +21,7 @@ pub struct Settings {
   pub mouse_scroll_speed: usize,
   pub scrollback_len: usize,
   pub proc_list_width: usize,
+  pub title: Option<String>,
 }
 
 impl Default for Settings {
@@ -33,6 +34,7 @@ impl Default for Settings {
       mouse_scroll_speed: 5,
       scrollback_len: 1000,
       proc_list_width: 30,
+      title: None,
     };
     settings.add_defaults();
     settings

--- a/src/ui_procs.rs
+++ b/src/ui_procs.rs
@@ -7,12 +7,18 @@ use tui::{
 };
 
 use crate::{
+  config::Config,
   proc::handle::ProcHandle,
   state::{Scope, State},
   theme::Theme,
 };
 
-pub fn render_procs(area: Rect, frame: &mut Frame, state: &mut State) {
+pub fn render_procs(
+  area: Rect,
+  frame: &mut Frame,
+  state: &mut State,
+  config: &Config,
+) {
   if area.width <= 2 {
     return;
   }
@@ -34,7 +40,10 @@ pub fn render_procs(area: Rect, frame: &mut Frame, state: &mut State) {
     .collect::<Vec<_>>();
 
   let title = {
-    let mut spans = vec![Span::styled("Processes", theme.pane_title(active))];
+    let mut spans = vec![Span::styled(
+      config.title.as_str(),
+      theme.pane_title(active),
+    )];
     if state.quitting {
       spans.push(Span::from(" "));
       spans.push(Span::styled(

--- a/src/ui_procs.rs
+++ b/src/ui_procs.rs
@@ -41,7 +41,7 @@ pub fn render_procs(
 
   let title = {
     let mut spans = vec![Span::styled(
-      config.title.as_str(),
+      config.proc_list_title.as_str(),
       theme.pane_title(active),
     )];
     if state.quitting {


### PR DESCRIPTION

This PR adds a `--title` argument to customize the text title of the processes pane.  This can also be set via a `title` string in the settings file. If not specified, it will default to the existing title of "Processes".

This can be useful when running multiple instances of `mprocs` in different windows and having a specific title makes it immediately obvious which project / set of processes is running in that window.  Note: `test-webapp-123` in the screenshot below. 

![image](https://github.com/user-attachments/assets/27f23eac-2100-49ff-b97b-bcdef1885a4c)

There are alternate ways to set unique titles for terminal windows outside of `mprocs`, but these can be terminal or window manager dependent, making it nice to be able to utilize `mprocs` to provide a unique title.  It's also already possible to achieve something similar by renaming the individual processes with `--names`. I personally find it useful to name the entire group of processes in `mprocs`, but no problem if you do not think the use cases are general enough to warrant merging this PR!  (Also very glad for any feedback on the code as I'm relatively new to Rust.)

	