### PR TITLE
feat: add C-c mapping to force quit

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ mprocs --npm
 Process list focused:
 
 - `q` - Quit (soft kill processes and wait then to exit)
-- `Q` - Force quit (terminate processes)
+- `Q` or `C-c` - Force quit (terminate processes)
 - `C-a` - Focus output pane
 - `x` - Soft kill selected process (send SIGTERM signal, hard kill on Windows)
 - `X` - Hard kill selected process (send SIGKILL)

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -230,7 +230,7 @@ impl Settings {
       AppEvent::ShowRenameProc,
     );
     let ctrlc = Key::new(KeyCode::Char('c'), KeyModifiers::CONTROL);
-    s.keymap_add_p(ctrlc, AppEvent::SendKey { key: ctrlc });
+    s.keymap_add_p(ctrlc, AppEvent::ForceQuit);
     s.keymap_add_p(
       Key::new(KeyCode::Char('a'), KeyModifiers::NONE),
       AppEvent::ShowAddProc,


### PR DESCRIPTION
It took me awhile to figure out that ctrl+c wouldn't quit the application. Given that there is no default keybinding for this, I think it should map to the `Q` force quit action.
