### PR TITLE
feat: add process groups for sidebar organization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Add process groups feature for organizing sidebar with collapsible groups
 - Add log_dir configuration in mprocs.yaml
 
 ## 0.8.3 - 2026-01-21

--- a/README.md
+++ b/README.md
@@ -177,6 +177,11 @@ settings in the _global_ config.
 - **log_dir**: _string|null_ - Default directory for process log files. Each
   process logs to `<log_dir>/<name>.log`. Prefix `<CONFIG_DIR>` will be replaced
   with the path of the directory where the config is located.
+- **groups**: _object_ - Define process groups for organizing the sidebar. Only
+  allowed in local config.
+  - **collapsed**: _bool_ - Start with group collapsed. Default: _false_.
+  - **procs**: _array<string>_ - List of process names to include in this group.
+    Process names must match keys defined in the **procs** section.
 - **keymap_procs**: _object_ - Key bindings for process list. See
   [Keymap](#keymap).
 - **keymap_term**: _object_ - Key bindings for terminal window. See
@@ -295,6 +300,7 @@ Process list focused:
 - `C-y` - Scroll output up by 3 lines
 - `z` - Zoom into terminal window
 - `v` - Enter copy mode
+- `Enter` or `Space` - Toggle selected group (expand/collapse)
 
 Process output focused:
 
@@ -363,6 +369,12 @@ Commands are encoded as yaml. Available commands:
 - `{c: send-key, key: "<KEY>"}` - Send key to current process. Key examples:
   `<C-a>`, `<Enter>`
 - `{c: batch, cmds: [{c: focus-procs}, …]}` - Send multiple commands
+- `{c: toggle-group, name: "<GROUP NAME>"}` - Toggle a group's collapsed state
+- `{c: collapse-group, name: "<GROUP NAME>"}` - Collapse a group
+- `{c: expand-group, name: "<GROUP NAME>"}` - Expand a group
+- `{c: collapse-all-groups}` - Collapse all groups
+- `{c: expand-all-groups}` - Expand all groups
+- `{c: toggle-selected-group}` - Toggle the currently selected group
 
 ## FAQ
 

--- a/src/event.rs
+++ b/src/event.rs
@@ -55,6 +55,14 @@ pub enum AppEvent {
   ToggleKeymapWindow,
 
   SendKey { key: Key },
+
+  // Group operations
+  ToggleGroup { name: String },
+  CollapseGroup { name: String },
+  ExpandGroup { name: String },
+  CollapseAllGroups,
+  ExpandAllGroups,
+  ToggleSelectedGroup,
 }
 
 impl CustomProcCmd for AppEvent {}
@@ -109,6 +117,12 @@ impl AppEvent {
       AppEvent::CopyModeCopy => "Copy selected text".to_string(),
       AppEvent::ToggleKeymapWindow => "Toggle help".to_string(),
       AppEvent::SendKey { key } => format!("Send {} key", key.to_string()),
+      AppEvent::ToggleGroup { name } => format!("Toggle group: {}", name),
+      AppEvent::CollapseGroup { name } => format!("Collapse group: {}", name),
+      AppEvent::ExpandGroup { name } => format!("Expand group: {}", name),
+      AppEvent::CollapseAllGroups => "Collapse all groups".to_string(),
+      AppEvent::ExpandAllGroups => "Expand all groups".to_string(),
+      AppEvent::ToggleSelectedGroup => "Toggle selected group".to_string(),
     }
   }
 }
@@ -159,5 +173,72 @@ mod tests {
       .unwrap(),
       "c: send-key\nkey: <C-a>\n"
     );
+  }
+
+  #[test]
+  fn serialize_group_events() {
+    // Test ToggleGroup serialization
+    assert_eq!(
+      serde_yaml::to_string(&AppEvent::ToggleGroup {
+        name: "backend".to_string()
+      })
+      .unwrap(),
+      "c: toggle-group\nname: backend\n"
+    );
+
+    // Test CollapseGroup serialization
+    assert_eq!(
+      serde_yaml::to_string(&AppEvent::CollapseGroup {
+        name: "frontend".to_string()
+      })
+      .unwrap(),
+      "c: collapse-group\nname: frontend\n"
+    );
+
+    // Test ExpandGroup serialization
+    assert_eq!(
+      serde_yaml::to_string(&AppEvent::ExpandGroup {
+        name: "test".to_string()
+      })
+      .unwrap(),
+      "c: expand-group\nname: test\n"
+    );
+
+    // Test CollapseAllGroups serialization
+    assert_eq!(
+      serde_yaml::to_string(&AppEvent::CollapseAllGroups).unwrap(),
+      "c: collapse-all-groups\n"
+    );
+
+    // Test ExpandAllGroups serialization
+    assert_eq!(
+      serde_yaml::to_string(&AppEvent::ExpandAllGroups).unwrap(),
+      "c: expand-all-groups\n"
+    );
+
+    // Test deserialization
+    let event: AppEvent =
+      serde_yaml::from_str("c: toggle-group\nname: backend\n").unwrap();
+    assert_eq!(
+      event,
+      AppEvent::ToggleGroup {
+        name: "backend".to_string()
+      }
+    );
+
+    let event: AppEvent =
+      serde_yaml::from_str("c: collapse-all-groups\n").unwrap();
+    assert_eq!(event, AppEvent::CollapseAllGroups);
+
+    // Test ToggleSelectedGroup serialization
+    assert_eq!(
+      serde_yaml::to_string(&AppEvent::ToggleSelectedGroup).unwrap(),
+      "c: toggle-selected-group\n"
+    );
+
+    // Test ToggleSelectedGroup deserialization
+    let event: AppEvent =
+      serde_yaml::from_str("c: toggle-selected-group\n").unwrap();
+    assert_eq!(event, AppEvent::ToggleSelectedGroup);
   }
 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -283,6 +283,16 @@ impl Settings {
       AppEvent::CopyModeEnter,
     );
 
+    // Group toggle keybindings (Enter and Space toggle selected group)
+    s.keymap_add_p(
+      Key::new(KeyCode::Enter, KeyModifiers::NONE),
+      AppEvent::ToggleSelectedGroup,
+    );
+    s.keymap_add_p(
+      Key::new(KeyCode::Char(' '), KeyModifiers::NONE),
+      AppEvent::ToggleSelectedGroup,
+    );
+
     for i in 0..8 {
       let char = char::from_digit(i + 1, 10).unwrap();
       s.keymap_add_p(

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,5 +1,6 @@
 use crate::{
   app::ClientId,
+  config::GroupConfig,
   kernel::proc::ProcId,
   keymap::KeymapGroup,
   proc::{view::ProcView, CopyMode},
@@ -11,6 +12,21 @@ pub enum Scope {
   Procs,
   Term,
   TermZoom,
+}
+
+/// Represents an item in the sidebar (either a group header or a process)
+#[derive(Clone, Debug)]
+pub enum SidebarItem {
+  Group { group_index: usize },
+  Process { proc_index: usize },
+}
+
+/// Runtime state for a process group
+#[derive(Clone, Debug)]
+pub struct GroupState {
+  pub name: String,
+  pub collapsed: bool,
+  pub proc_indices: Vec<usize>,
 }
 
 impl Scope {
@@ -40,25 +56,68 @@ pub struct State {
   pub hide_keymap_window: bool,
 
   pub quitting: bool,
+
+  /// Group states (runtime)
+  pub groups: Vec<GroupState>,
+  /// Computed view of sidebar items (groups and processes)
+  pub sidebar_items: Vec<SidebarItem>,
 }
 
 impl State {
+  /// Returns the selected sidebar index
   pub fn selected(&self) -> usize {
     self.procs_list.selected()
   }
 
+  /// Returns the currently selected sidebar item
+  pub fn get_selected_sidebar_item(&self) -> Option<&SidebarItem> {
+    self.sidebar_items.get(self.procs_list.selected())
+  }
+
+  /// Returns the proc index if the currently selected sidebar item is a process
+  pub fn selected_proc_index(&self) -> Option<usize> {
+    match self.get_selected_sidebar_item() {
+      Some(SidebarItem::Process { proc_index }) => Some(*proc_index),
+      _ => None,
+    }
+  }
+
   pub fn get_current_proc(&self) -> Option<&ProcView> {
-    self.procs.get(self.procs_list.selected())
+    self.selected_proc_index().and_then(|i| self.procs.get(i))
   }
 
   pub fn get_current_proc_mut(&mut self) -> Option<&mut ProcView> {
-    self.procs.get_mut(self.procs_list.selected())
+    self
+      .selected_proc_index()
+      .and_then(|i| self.procs.get_mut(i))
   }
 
-  pub fn select_proc(&mut self, index: usize) {
+  /// Select a sidebar item by its index
+  pub fn select_sidebar_item(&mut self, index: usize) {
     self.procs_list.select(index);
-    if let Some(proc_handle) = self.procs.get_mut(index) {
-      proc_handle.focus();
+    if let Some(SidebarItem::Process { proc_index }) =
+      self.sidebar_items.get(index)
+    {
+      if let Some(proc_handle) = self.procs.get_mut(*proc_index) {
+        proc_handle.focus();
+      }
+    }
+  }
+
+  /// Legacy method for selecting a proc by its index in the procs list
+  pub fn select_proc(&mut self, proc_idx: usize) {
+    // Find the sidebar index for this proc
+    for (sidebar_idx, item) in self.sidebar_items.iter().enumerate() {
+      if let SidebarItem::Process { proc_index } = item {
+        if *proc_index == proc_idx {
+          self.select_sidebar_item(sidebar_idx);
+          return;
+        }
+      }
+    }
+    // Fallback: if proc not in sidebar (shouldn't happen), select first item
+    if !self.sidebar_items.is_empty() {
+      self.select_sidebar_item(0);
     }
   }
 
@@ -85,5 +144,450 @@ impl State {
 
   pub fn toggle_keymap_window(&mut self) {
     self.hide_keymap_window = !self.hide_keymap_window;
+  }
+
+  /// Initialize groups from config
+  pub fn init_groups(&mut self, group_configs: &[GroupConfig]) {
+    self.groups = group_configs
+      .iter()
+      .map(|cfg| GroupState {
+        name: cfg.name.clone(),
+        collapsed: cfg.collapsed,
+        proc_indices: Vec::new(),
+      })
+      .collect();
+  }
+
+  /// Populate group proc_indices after procs are started
+  pub fn populate_group_indices(&mut self, group_configs: &[GroupConfig]) {
+    // Build a map from proc name to proc index
+    let proc_name_to_idx: std::collections::HashMap<_, _> = self
+      .procs
+      .iter()
+      .enumerate()
+      .map(|(idx, p)| (p.name().to_string(), idx))
+      .collect();
+
+    // Populate each group's proc_indices
+    for (group_idx, group_cfg) in group_configs.iter().enumerate() {
+      if let Some(group) = self.groups.get_mut(group_idx) {
+        group.proc_indices = group_cfg
+          .proc_names
+          .iter()
+          .filter_map(|name| proc_name_to_idx.get(name).copied())
+          .collect();
+      }
+    }
+  }
+
+  /// Rebuild the sidebar_items list based on current groups and procs
+  pub fn rebuild_sidebar_items(&mut self) {
+    let mut items = Vec::new();
+    let mut grouped_proc_indices = std::collections::HashSet::new();
+
+    // Add groups and their processes
+    for (group_idx, group) in self.groups.iter().enumerate() {
+      items.push(SidebarItem::Group { group_index: group_idx });
+
+      if !group.collapsed {
+        for &proc_idx in &group.proc_indices {
+          items.push(SidebarItem::Process { proc_index: proc_idx });
+          grouped_proc_indices.insert(proc_idx);
+        }
+      } else {
+        // Still track grouped procs even when collapsed
+        for &proc_idx in &group.proc_indices {
+          grouped_proc_indices.insert(proc_idx);
+        }
+      }
+    }
+
+    // Add ungrouped processes at the bottom
+    for (proc_idx, _proc) in self.procs.iter().enumerate() {
+      if !grouped_proc_indices.contains(&proc_idx) {
+        items.push(SidebarItem::Process { proc_index: proc_idx });
+      }
+    }
+
+    self.sidebar_items = items;
+  }
+
+  /// Toggle a group's collapsed state by group index
+  pub fn toggle_group(&mut self, group_idx: usize) {
+    if let Some(group) = self.groups.get_mut(group_idx) {
+      group.collapsed = !group.collapsed;
+    }
+  }
+
+  /// Toggle a group by name (for remote commands)
+  pub fn toggle_group_by_name(&mut self, name: &str) -> bool {
+    if let Some(group) = self.groups.iter_mut().find(|g| g.name == name) {
+      group.collapsed = !group.collapsed;
+      true
+    } else {
+      false
+    }
+  }
+
+  /// Collapse a group by name
+  pub fn collapse_group_by_name(&mut self, name: &str) -> bool {
+    if let Some(group) = self.groups.iter_mut().find(|g| g.name == name) {
+      group.collapsed = true;
+      true
+    } else {
+      false
+    }
+  }
+
+  /// Expand a group by name
+  pub fn expand_group_by_name(&mut self, name: &str) -> bool {
+    if let Some(group) = self.groups.iter_mut().find(|g| g.name == name) {
+      group.collapsed = false;
+      true
+    } else {
+      false
+    }
+  }
+
+  /// Collapse all groups
+  pub fn collapse_all_groups(&mut self) {
+    for group in &mut self.groups {
+      group.collapsed = true;
+    }
+  }
+
+  /// Expand all groups
+  pub fn expand_all_groups(&mut self) {
+    for group in &mut self.groups {
+      group.collapsed = false;
+    }
+  }
+
+  /// Handle selection adjustment after a group collapse
+  /// If the selected item is inside a collapsed group, move selection to the group header
+  pub fn adjust_selection_after_collapse(&mut self) {
+    let selected = self.procs_list.selected();
+
+    // If current selection is beyond the new sidebar_items length, adjust
+    if selected >= self.sidebar_items.len() && !self.sidebar_items.is_empty() {
+      self
+        .procs_list
+        .select(self.sidebar_items.len().saturating_sub(1));
+    }
+  }
+
+  /// Returns the number of sidebar items
+  pub fn sidebar_len(&self) -> usize {
+    self.sidebar_items.len()
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  fn make_test_state() -> State {
+    State {
+      current_client_id: None,
+      scope: Scope::Procs,
+      procs: Vec::new(),
+      procs_list: ListState::default(),
+      hide_keymap_window: false,
+      quitting: false,
+      groups: Vec::new(),
+      sidebar_items: Vec::new(),
+    }
+  }
+
+  fn make_group_configs() -> Vec<GroupConfig> {
+    vec![
+      GroupConfig {
+        name: "backend".to_string(),
+        collapsed: false,
+        proc_names: vec!["server".to_string(), "worker".to_string()],
+      },
+      GroupConfig {
+        name: "frontend".to_string(),
+        collapsed: true,
+        proc_names: vec!["client".to_string()],
+      },
+    ]
+  }
+
+  #[test]
+  fn test_init_groups_empty() {
+    let mut state = make_test_state();
+    state.init_groups(&[]);
+    assert!(state.groups.is_empty());
+  }
+
+  #[test]
+  fn test_init_groups_single() {
+    let mut state = make_test_state();
+    let configs = vec![GroupConfig {
+      name: "test".to_string(),
+      collapsed: false,
+      proc_names: vec!["proc1".to_string()],
+    }];
+    state.init_groups(&configs);
+
+    assert_eq!(state.groups.len(), 1);
+    assert_eq!(state.groups[0].name, "test");
+    assert!(!state.groups[0].collapsed);
+    // proc_indices are populated by populate_group_indices, not init_groups
+    assert!(state.groups[0].proc_indices.is_empty());
+  }
+
+  #[test]
+  fn test_init_groups_preserves_collapsed_state() {
+    let mut state = make_test_state();
+    let configs = make_group_configs();
+    state.init_groups(&configs);
+
+    assert_eq!(state.groups.len(), 2);
+    assert!(!state.groups[0].collapsed); // backend
+    assert!(state.groups[1].collapsed); // frontend
+  }
+
+  #[test]
+  fn test_toggle_group_by_name_existing() {
+    let mut state = make_test_state();
+    state.groups = vec![GroupState {
+      name: "test".to_string(),
+      collapsed: false,
+      proc_indices: Vec::new(),
+    }];
+
+    let result = state.toggle_group_by_name("test");
+    assert!(result);
+    assert!(state.groups[0].collapsed);
+
+    let result = state.toggle_group_by_name("test");
+    assert!(result);
+    assert!(!state.groups[0].collapsed);
+  }
+
+  #[test]
+  fn test_toggle_group_by_name_nonexistent() {
+    let mut state = make_test_state();
+    state.groups = vec![GroupState {
+      name: "test".to_string(),
+      collapsed: false,
+      proc_indices: Vec::new(),
+    }];
+
+    let result = state.toggle_group_by_name("nonexistent");
+    assert!(!result);
+    // Original group should be unchanged
+    assert!(!state.groups[0].collapsed);
+  }
+
+  #[test]
+  fn test_collapse_group_by_name() {
+    let mut state = make_test_state();
+    state.groups = vec![GroupState {
+      name: "test".to_string(),
+      collapsed: false,
+      proc_indices: Vec::new(),
+    }];
+
+    let result = state.collapse_group_by_name("test");
+    assert!(result);
+    assert!(state.groups[0].collapsed);
+
+    // Calling again should still return true and stay collapsed
+    let result = state.collapse_group_by_name("test");
+    assert!(result);
+    assert!(state.groups[0].collapsed);
+  }
+
+  #[test]
+  fn test_expand_group_by_name() {
+    let mut state = make_test_state();
+    state.groups = vec![GroupState {
+      name: "test".to_string(),
+      collapsed: true,
+      proc_indices: Vec::new(),
+    }];
+
+    let result = state.expand_group_by_name("test");
+    assert!(result);
+    assert!(!state.groups[0].collapsed);
+
+    // Calling again should still return true and stay expanded
+    let result = state.expand_group_by_name("test");
+    assert!(result);
+    assert!(!state.groups[0].collapsed);
+  }
+
+  #[test]
+  fn test_collapse_all_groups() {
+    let mut state = make_test_state();
+    state.groups = vec![
+      GroupState {
+        name: "group1".to_string(),
+        collapsed: false,
+        proc_indices: Vec::new(),
+      },
+      GroupState {
+        name: "group2".to_string(),
+        collapsed: false,
+        proc_indices: Vec::new(),
+      },
+    ];
+
+    state.collapse_all_groups();
+
+    assert!(state.groups[0].collapsed);
+    assert!(state.groups[1].collapsed);
+  }
+
+  #[test]
+  fn test_expand_all_groups() {
+    let mut state = make_test_state();
+    state.groups = vec![
+      GroupState {
+        name: "group1".to_string(),
+        collapsed: true,
+        proc_indices: Vec::new(),
+      },
+      GroupState {
+        name: "group2".to_string(),
+        collapsed: true,
+        proc_indices: Vec::new(),
+      },
+    ];
+
+    state.expand_all_groups();
+
+    assert!(!state.groups[0].collapsed);
+    assert!(!state.groups[1].collapsed);
+  }
+
+  #[test]
+  fn test_toggle_group_by_index() {
+    let mut state = make_test_state();
+    state.groups = vec![
+      GroupState {
+        name: "group1".to_string(),
+        collapsed: false,
+        proc_indices: Vec::new(),
+      },
+      GroupState {
+        name: "group2".to_string(),
+        collapsed: true,
+        proc_indices: Vec::new(),
+      },
+    ];
+
+    state.toggle_group(0);
+    assert!(state.groups[0].collapsed);
+
+    state.toggle_group(1);
+    assert!(!state.groups[1].collapsed);
+  }
+
+  #[test]
+  fn test_toggle_group_by_index_out_of_bounds() {
+    let mut state = make_test_state();
+    state.groups = vec![GroupState {
+      name: "group1".to_string(),
+      collapsed: false,
+      proc_indices: Vec::new(),
+    }];
+
+    // Should not panic
+    state.toggle_group(10);
+    // Original group should be unchanged
+    assert!(!state.groups[0].collapsed);
+  }
+
+  #[test]
+  fn test_sidebar_len() {
+    let mut state = make_test_state();
+    state.sidebar_items = vec![
+      SidebarItem::Group { group_index: 0 },
+      SidebarItem::Process { proc_index: 0 },
+      SidebarItem::Process { proc_index: 1 },
+    ];
+
+    assert_eq!(state.sidebar_len(), 3);
+  }
+
+  #[test]
+  fn test_selected_proc_index_when_group_selected() {
+    let mut state = make_test_state();
+    state.sidebar_items = vec![
+      SidebarItem::Group { group_index: 0 },
+      SidebarItem::Process { proc_index: 0 },
+    ];
+    // Configure the ListState to know about item count
+    state
+      .procs_list
+      .fit(crate::vt100::grid::Rect::new(0, 0, 10, 10), 2);
+    state.procs_list.select(0); // Select the group
+
+    assert_eq!(state.selected_proc_index(), None);
+  }
+
+  #[test]
+  fn test_selected_proc_index_when_proc_selected() {
+    let mut state = make_test_state();
+    state.sidebar_items = vec![
+      SidebarItem::Group { group_index: 0 },
+      SidebarItem::Process { proc_index: 0 },
+    ];
+    // Configure the ListState to know about item count
+    state
+      .procs_list
+      .fit(crate::vt100::grid::Rect::new(0, 0, 10, 10), 2);
+    state.procs_list.select(1); // Select the process
+
+    assert_eq!(state.selected_proc_index(), Some(0));
+  }
+
+  #[test]
+  fn test_get_selected_sidebar_item() {
+    let mut state = make_test_state();
+    state.sidebar_items = vec![
+      SidebarItem::Group { group_index: 0 },
+      SidebarItem::Process { proc_index: 0 },
+    ];
+    // Configure the ListState to know about item count
+    state
+      .procs_list
+      .fit(crate::vt100::grid::Rect::new(0, 0, 10, 10), 2);
+
+    state.procs_list.select(0);
+    match state.get_selected_sidebar_item() {
+      Some(SidebarItem::Group { group_index }) => assert_eq!(*group_index, 0),
+      _ => panic!("Expected Group"),
+    }
+
+    state.procs_list.select(1);
+    match state.get_selected_sidebar_item() {
+      Some(SidebarItem::Process { proc_index }) => assert_eq!(*proc_index, 0),
+      _ => panic!("Expected Process"),
+    }
+  }
+
+  #[test]
+  fn test_adjust_selection_after_collapse() {
+    let mut state = make_test_state();
+    state.sidebar_items = vec![
+      SidebarItem::Group { group_index: 0 },
+      SidebarItem::Process { proc_index: 0 },
+    ];
+    // Configure the ListState with a count larger than sidebar_items
+    // to simulate an out-of-bounds selection
+    state
+      .procs_list
+      .fit(crate::vt100::grid::Rect::new(0, 0, 10, 10), 10);
+    state.procs_list.select(5); // Selection beyond sidebar length
+
+    state.adjust_selection_after_collapse();
+
+    // Should adjust to last valid index
+    assert_eq!(state.procs_list.selected(), 1);
   }
 }

--- a/src/ui_procs.rs
+++ b/src/ui_procs.rs
@@ -4,7 +4,7 @@ use unicode_width::UnicodeWidthStr;
 
 use crate::{
   config::Config,
-  state::{Scope, State},
+  state::{Scope, SidebarItem, State},
   vt100::{
     attrs::Attrs,
     grid::{BorderType, Rect},
@@ -18,7 +18,8 @@ pub fn render_procs(
   state: &mut State,
   config: &Config,
 ) {
-  state.procs_list.fit(area.inner(1), state.procs.len());
+  // Fit the list to sidebar items count instead of procs count
+  state.procs_list.fit(area.inner(1), state.sidebar_items.len());
 
   if area.width <= 2 {
     return;
@@ -63,14 +64,15 @@ pub fn render_procs(
   }
 
   let range = state.procs_list.visible_range();
-  for (row, index) in range.enumerate() {
-    let proc = if let Some(proc) = state.procs.get(index) {
-      proc
+  for (row, sidebar_index) in range.enumerate() {
+    let sidebar_item = if let Some(item) = state.sidebar_items.get(sidebar_index)
+    {
+      item.clone()
     } else {
       continue;
     };
 
-    let selected = index == state.selected();
+    let selected = sidebar_index == state.selected();
     let attrs = if selected {
       Attrs::default().bg(crate::vt100::Color::Idx(240))
     } else {
@@ -83,47 +85,96 @@ pub fn render_procs(
       height: 1,
     };
 
-    let r = grid.draw_text(row_area, if selected { "•" } else { " " }, attrs);
-    row_area.x += r.width;
-    row_area.width = row_area.width.saturating_sub(r.width);
+    match sidebar_item {
+      SidebarItem::Group { group_index } => {
+        // Render group header
+        if let Some(group) = state.groups.get(group_index) {
+          let indicator = if group.collapsed { "▸" } else { "▾" };
+          let r = grid.draw_text(
+            row_area,
+            if selected { indicator } else { indicator },
+            attrs.clone().set_bold(true),
+          );
+          row_area.x += r.width;
+          row_area.width = row_area.width.saturating_sub(r.width);
 
-    let r = grid.draw_text(row_area, proc.name(), attrs);
-    row_area.x += r.width;
-    row_area.width = row_area.width.saturating_sub(r.width);
+          let r = grid.draw_text(row_area, " ", attrs);
+          row_area.x += r.width;
+          row_area.width = row_area.width.saturating_sub(r.width);
 
-    let (status_text, status_attrs) = if proc.is_up() {
-      (
-        Cow::from(" UP "),
-        attrs.clone().set_bold(true).fg(Color::BRIGHT_GREEN),
-      )
-    } else {
-      match proc.exit_code() {
-        Some(0) => {
-          (Cow::from(" DOWN (0)"), attrs.clone().fg(Color::BRIGHT_BLUE))
+          let r =
+            grid.draw_text(row_area, &group.name, attrs.clone().set_bold(true));
+          row_area.x += r.width;
+          row_area.width = row_area.width.saturating_sub(r.width);
+
+          grid.fill_area(row_area, ' ', attrs);
         }
-        Some(exit_code) => (
-          Cow::from(format!(" DOWN ({})", exit_code)),
-          attrs.clone().fg(Color::BRIGHT_RED),
-        ),
-        None => (Cow::from(" DOWN "), attrs.clone().fg(Color::BRIGHT_RED)),
       }
-    };
-    let status_width = status_text.width() as u16;
-    let r = grid.draw_text(
-      Rect {
-        x: row_area.x.max(row_area.x + row_area.width - status_width),
-        width: status_width.min(row_area.width),
-        ..row_area
-      },
-      &status_text,
-      status_attrs,
-    );
-    row_area.width = row_area.width.saturating_sub(r.width);
+      SidebarItem::Process { proc_index } => {
+        // Check if this process is in a group (for indentation)
+        let is_grouped = state
+          .groups
+          .iter()
+          .any(|g| g.proc_indices.contains(&proc_index));
 
-    grid.fill_area(row_area, ' ', attrs);
+        let proc = if let Some(proc) = state.procs.get(proc_index) {
+          proc
+        } else {
+          continue;
+        };
+
+        // Add indentation for grouped processes
+        if is_grouped {
+          let r = grid.draw_text(row_area, "  ", attrs);
+          row_area.x += r.width;
+          row_area.width = row_area.width.saturating_sub(r.width);
+        }
+
+        let r =
+          grid.draw_text(row_area, if selected { "*" } else { " " }, attrs);
+        row_area.x += r.width;
+        row_area.width = row_area.width.saturating_sub(r.width);
+
+        let r = grid.draw_text(row_area, proc.name(), attrs);
+        row_area.x += r.width;
+        row_area.width = row_area.width.saturating_sub(r.width);
+
+        let (status_text, status_attrs) = if proc.is_up() {
+          (
+            Cow::from(" UP "),
+            attrs.clone().set_bold(true).fg(Color::BRIGHT_GREEN),
+          )
+        } else {
+          match proc.exit_code() {
+            Some(0) => {
+              (Cow::from(" DOWN (0)"), attrs.clone().fg(Color::BRIGHT_BLUE))
+            }
+            Some(exit_code) => (
+              Cow::from(format!(" DOWN ({})", exit_code)),
+              attrs.clone().fg(Color::BRIGHT_RED),
+            ),
+            None => (Cow::from(" DOWN "), attrs.clone().fg(Color::BRIGHT_RED)),
+          }
+        };
+        let status_width = status_text.width() as u16;
+        let r = grid.draw_text(
+          Rect {
+            x: row_area.x.max(row_area.x + row_area.width - status_width),
+            width: status_width.min(row_area.width),
+            ..row_area
+          },
+          &status_text,
+          status_attrs,
+        );
+        row_area.width = row_area.width.saturating_sub(r.width);
+
+        grid.fill_area(row_area, ' ', attrs);
+      }
+    }
   }
 }
 
+/// Returns the sidebar index of the clicked item
 pub fn procs_get_clicked_index(
   area: Rect,
   x: u16,
@@ -132,10 +183,10 @@ pub fn procs_get_clicked_index(
 ) -> Option<usize> {
   let inner = area.inner(1);
   if procs_check_hit(area, x, y) {
-    let index = y - inner.y;
-    let scroll = (state.selected() + 1).saturating_sub(inner.height as usize);
-    let index = index as usize + scroll;
-    if index < state.procs.len() {
+    let row_offset = y - inner.y;
+    let top_index = state.procs_list.top_index();
+    let index = row_offset as usize + top_index;
+    if index < state.sidebar_items.len() {
       return Some(index);
     }
   }

--- a/src/widgets/list.rs
+++ b/src/widgets/list.rs
@@ -66,4 +66,8 @@ impl ListState {
   pub fn selected(&self) -> usize {
     self.selected as usize
   }
+
+  pub fn top_index(&self) -> usize {
+    self.top_index as usize
+  }
 }


### PR DESCRIPTION
## Summary

- Add collapsible process groups for organizing the sidebar
- Groups can be defined in config with a list of process names
- Groups can start collapsed or expanded via `collapsed` config option
- Enter/Space toggles the selected group (expand/collapse)
- Remote control commands for programmatic group manipulation
- Comprehensive test coverage for config parsing and state management
- Documentation updates in README and CHANGELOG

## Configuration Example

```yaml
procs:
  server: "node server.js"
  worker: "node worker.js"
  client: "npm run dev"

groups:
  backend:
    procs:
      - server
      - worker
  frontend:
    collapsed: true
    procs:
      - client
```

## New Remote Control Commands

- `{c: toggle-group, name: "<GROUP NAME>"}` - Toggle a group's collapsed state
- `{c: collapse-group, name: "<GROUP NAME>"}` - Collapse a group
- `{c: expand-group, name: "<GROUP NAME>"}` - Expand a group
- `{c: collapse-all-groups}` - Collapse all groups
- `{c: expand-all-groups}` - Expand all groups
- `{c: toggle-selected-group}` - Toggle the currently selected group

## Test Plan

- [x] All new config parsing tests pass
- [x] All new state manipulation tests pass
- [x] Event serialization tests pass
- [x] `cargo clippy` passes (no new warnings)

closes #117