### PR TITLE
Add cmd stop signal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+- Add `{cmd: <shell>}` value for `stop` to run a shell command as the stop
+  action (useful for tools like `podman compose` that don't respond to
+  signals reliably)
+
 ## 0.9.2 - 2026-03-21
 
 - Fixed Cyrillic input

--- a/README.md
+++ b/README.md
@@ -162,8 +162,11 @@ settings in the _global_ config.
     environment variable.
   - **autostart**: _bool_ - Start process when mprocs starts. Default: _true_.
   - **autorestart**: _bool_ - Restart process when it exits. Default: false. Note: If process exits within 1 second of starting, it will not be restarted.
-  - **stop**: _"SIGINT"|"SIGTERM"|"SIGKILL"|{send-keys: array<key>}|"hard-kill"_ -
-    A way to stop a process (using `x` key or when quitting mprocs).
+  - **stop**: _"SIGINT"|"SIGTERM"|"SIGKILL"|{send-keys: array<key>}|{cmd: string}|"hard-kill"_ -
+    A way to stop a process (using `x` key or when quitting mprocs). The `cmd`
+    form runs a shell command (e.g. `podman compose down`) instead of
+    signaling the proc. The proc is expected to exit on its own once the
+    command takes effect.
   - **log**: _bool|string|object|null_ - Process logging config. A string is a
     shorthand for `{ dir: ... }`. `true` enables logging with defaults.
     - **dir**: _string|null_ - Directory for per-process log files.

--- a/src/mprocs/proc/mod.rs
+++ b/src/mprocs/proc/mod.rs
@@ -19,6 +19,12 @@ pub enum StopSignal {
   SIGKILL,
   SendKeys(Vec<Key>),
   HardKill,
+  /// Run a shell command as the stop action. Useful for tools like
+  /// `podman compose` that don't reliably respond to signals but do have
+  /// an explicit teardown command (e.g. `podman compose down`). The main
+  /// process is expected to exit on its own once the stop command
+  /// completes (e.g. `compose up` exits when containers go away).
+  Cmd(String),
 }
 
 impl StopSignal {
@@ -36,6 +42,12 @@ impl StopSignal {
           if let Some(keys) = map.get("send-keys") {
             let keys: Vec<Key> = serde_yaml::from_value(keys.clone())?;
             return Ok(Self::SendKeys(keys));
+          }
+          if let Some(cmd) = map.get("cmd") {
+            if let serde_yaml::Value::String(shell) = cmd {
+              return Ok(Self::Cmd(shell.clone()));
+            }
+            bail!("Expected 'cmd' to be a string");
           }
         }
       }

--- a/src/mprocs/proc/proc.rs
+++ b/src/mprocs/proc/proc.rs
@@ -322,6 +322,7 @@ impl Proc {
         }
       }
       StopSignal::HardKill => self.kill().await,
+      StopSignal::Cmd(shell) => self.run_stop_cmd(shell),
     }
   }
 
@@ -337,7 +338,49 @@ impl Proc {
         }
       }
       StopSignal::HardKill => self.kill().await,
+      StopSignal::Cmd(shell) => self.run_stop_cmd(shell),
     }
+  }
+
+  /// Spawn the configured stop command as a separate subprocess. Inherits
+  /// the proc's cwd and env so commands like `podman compose down` target
+  /// the same project. Output is discarded. The main proc is expected to
+  /// exit on its own once the command takes effect.
+  fn run_stop_cmd(&self, shell: String) {
+    let cwd = self.spec.cwd.clone();
+    let env = self.spec.env.clone();
+    tokio::spawn(async move {
+      #[cfg(windows)]
+      let mut cmd = {
+        let mut c = tokio::process::Command::new("pwsh.exe");
+        c.arg("-Command").arg(&shell);
+        c
+      };
+      #[cfg(not(windows))]
+      let mut cmd = {
+        let mut c = tokio::process::Command::new("/bin/sh");
+        c.arg("-c").arg(&shell);
+        c
+      };
+      if let Some(cwd) = &cwd {
+        cmd.current_dir(cwd);
+      }
+      for (k, v) in &env {
+        match v {
+          Some(v) => {
+            cmd.env(k, v);
+          }
+          None => {
+            cmd.env_remove(k);
+          }
+        }
+      }
+      cmd.stdout(std::process::Stdio::null());
+      cmd.stderr(std::process::Stdio::null());
+      if let Err(e) = cmd.status().await {
+        log::warn!("Stop command failed: {}", e);
+      }
+    });
   }
 
   #[cfg(not(windows))]


### PR DESCRIPTION
Allows configuring a shell command as a proc's stop action. Useful for tools like `podman compose` that may not respond to signals reliably depending on how they are spawned but which have an explicit teardown command (e.g. podman compose down). The main proc is expected to exit on its own once the stop command completes.

For me in my environment this is working better for stopping podman compose tasks than the other stop methods (I tried a few different approaches)

