### PR TITLE
docs: remove unmaintained MPR installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,6 @@ shows output of each command separately and allows to interact with processes
   - [cargo (All platforms)](#cargo-all-platforms)
   - [scoop (Windows)](#scoop-windows)
   - [AUR (Arch Linux)](#aur-arch-linux)
-  - [MPR (Debian/Ubuntu)](#mpr-debianubuntu)
 - [Usage](#usage)
   - [Config](#config)
     - [Keymap](#keymap)
@@ -102,14 +101,6 @@ yay mprocs
 
 ```sh
 yay mprocs-bin
-```
-
-### MPR (Debian/Ubuntu)
-
-```sh
-git clone 'https://mpr.makedeb.org/mprocs'
-cd mprocs/
-makedeb -si
 ```
 
 ## Usage


### PR DESCRIPTION
Fixes #185

The MPR (makedeb) installation method no longer works as the package has been removed from the repository. This PR removes the broken installation instructions from the README.