### PR TITLE
Show autostart:false procs in gray instead of red

### DIFF
--- a/src/mprocs/ui_procs.rs
+++ b/src/mprocs/ui_procs.rs
@@ -106,7 +106,14 @@ pub fn render_procs(
           Cow::from(format!(" DOWN ({})", exit_code)),
           attrs.clone().fg(Color::BRIGHT_RED),
         ),
-        None => (Cow::from(" DOWN "), attrs.clone().fg(Color::BRIGHT_RED)),
+        None => {
+          // Process never started - check if autostart is false
+          if !proc.cfg.autostart {
+            (Cow::from(" DOWN "), attrs.clone().fg(Color::BRIGHT_BLACK))
+          } else {
+            (Cow::from(" DOWN "), attrs.clone().fg(Color::BRIGHT_RED))
+          }
+        }
       }
     };
     let status_width = status_text.width() as u16;


### PR DESCRIPTION
Fixes #212

Processes with `autostart: false` that have never been started now show in gray (BRIGHT_BLACK) instead of red. Red is reserved for processes that exited with a nonzero code or crashed unexpectedly.

The change is in the `None` exit-code branch of `render_procs`: when `proc.cfg.autostart` is false, the status color is gray; otherwise it stays red.