### PR TITLE
fix: replace blocking stdout with async tokio::io::stdout in client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Add `{cmd: <shell>}` value for `stop` to run a shell command as the stop
   action (useful for tools like `podman compose` that don't respond to
   signals reliably)
+- Fix client hang under terminal backpressure by using async stdout writes
 
 ## 0.9.2 - 2026-03-21
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,7 +1,7 @@
-use std::io::{stdout, Write};
+use tokio::io::AsyncWriteExt;
 
-use crate::term::key::{Key, KeyEventKind};
 use crate::term::TermEvent;
+use crate::term::key::{Key, KeyEventKind};
 use crate::term_driver::TermDriver;
 use crate::{
   daemon::{receiver::MsgReceiver, sender::MsgSender},
@@ -36,6 +36,8 @@ async fn client_main_loop(
     TermEvent(std::io::Result<Option<TermEvent>>),
   }
 
+  let mut stdout = tokio::io::stdout();
+
   loop {
     let event = tokio::select! {
       msg = receiver.recv() => {
@@ -49,13 +51,13 @@ async fn client_main_loop(
       LocalEvent::ServerMsg(msg) => match msg {
         Some(msg) => match msg {
           SrvToClt::Print(text) => {
-            std::io::stdout().write_all(text.as_bytes())?;
+            stdout.write_all(text.as_bytes()).await?;
           }
           SrvToClt::Flush => {
-            stdout().flush()?;
+            stdout.flush().await?;
           }
           SrvToClt::Quit => break,
-          SrvToClt::Rpc(_) => {},
+          SrvToClt::Rpc(_) => {}
         },
         _ => break,
       },
@@ -69,6 +71,10 @@ async fn client_main_loop(
       },
     }
   }
+
+  // Make sure any buffered bytes hit the terminal before TermDriver::drop
+  // restores its state.
+  let _ = stdout.flush().await;
 
   Ok(())
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -72,8 +72,6 @@ async fn client_main_loop(
     }
   }
 
-  // Make sure any buffered bytes hit the terminal before TermDriver::drop
-  // restores its state.
   let _ = stdout.flush().await;
 
   Ok(())


### PR DESCRIPTION
`std::io::stdout()` with synchronous `write_all`/`flush` calls blocks the
tokio thread when the terminal is under backpressure (e.g. slow consumer,
large output burst). This causes the entire async runtime to stall, making
mprocs appear frozen.

Switch to `tokio::io::stdout()` and `.await` the writes so the runtime can
schedule other tasks while waiting for the terminal to drain. Also add a
final flush before returning so buffered bytes reach the terminal before
`TermDriver::drop` restores terminal state.