### PR TITLE
fix: drop disconnected clients instead of panicking on send

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
   action (useful for tools like `podman compose` that don't respond to
   signals reliably)
 - Fix client hang under terminal backpressure by using async stdout writes
+- Fix server panic when a client disconnects during render
 
 ## 0.9.2 - 2026-03-21
 

--- a/src/mprocs/app.rs
+++ b/src/mprocs/app.rs
@@ -5,23 +5,6 @@ use futures::{future::FutureExt, select};
 use serde::{Deserialize, Serialize};
 use tokio::{io::AsyncReadExt, sync::mpsc::UnboundedReceiver};
 
-use crate::{
-  daemon::{receiver::MsgReceiver, sender::MsgSender},
-  error::ResultLogger,
-  kernel::{
-    kernel_message::{KernelCommand, TaskContext, TaskSender},
-    task::{TaskCmd, TaskDef, TaskId, TaskNotification, TaskNotify, TaskStatus},
-  },
-  protocol::{CltToSrv, SrvToClt},
-  server::server_message::ServerMessage,
-  term::{
-    Grid, MouseProtocolMode, ScreenDiffer, Size, TermEvent,
-    attrs::Attrs,
-    grid::Rect,
-    key::{Key, KeyEventKind},
-    mouse::{MouseButton, MouseEventKind},
-  },
-};
 use crate::mprocs::{
   config::{CmdConfig, Config, ProcConfig, ServerConfig},
   event::{AppEvent, CopyMove},
@@ -43,6 +26,25 @@ use crate::mprocs::{
   ui_term::{render_term, term_check_hit},
   ui_zoom_tip::render_zoom_tip,
   widgets::list::ListState,
+};
+use crate::{
+  daemon::{receiver::MsgReceiver, sender::MsgSender},
+  error::ResultLogger,
+  kernel::{
+    kernel_message::{KernelCommand, TaskContext, TaskSender},
+    task::{
+      TaskCmd, TaskDef, TaskId, TaskNotification, TaskNotify, TaskStatus,
+    },
+  },
+  protocol::{CltToSrv, SrvToClt},
+  server::server_message::ServerMessage,
+  term::{
+    Grid, MouseProtocolMode, ScreenDiffer, Size, TermEvent,
+    attrs::Attrs,
+    grid::Rect,
+    key::{Key, KeyEventKind},
+    mouse::{MouseButton, MouseEventKind},
+  },
 };
 
 #[derive(Debug, Default, PartialEq)]
@@ -193,26 +195,19 @@ impl App {
           modal.render(grid);
         }
 
-        let mut dead_clients: Vec<usize> = Vec::new();
-        for (idx, client_handle) in self.clients.iter_mut().enumerate() {
+        for client_handle in &mut self.clients {
           let mut out = String::new();
           client_handle.differ.diff(&mut out, grid).log_ignore();
-          if client_handle
+          client_handle
             .sender
             .send(SrvToClt::Print(out))
             .await
-            .is_err()
-            || client_handle
-              .sender
-              .send(SrvToClt::Flush)
-              .await
-              .is_err()
-          {
-            dead_clients.push(idx);
-          }
-        }
-        for idx in dead_clients.into_iter().rev() {
-          self.clients.swap_remove(idx);
+            .log_ignore();
+          client_handle
+            .sender
+            .send(SrvToClt::Flush)
+            .await
+            .log_ignore();
         }
       }
 
@@ -958,7 +953,7 @@ impl App {
           return;
         }
         log::error!("App received unknown Msg");
-      },
+      }
     }
   }
 
@@ -995,8 +990,7 @@ impl App {
             TargetState::None if proc.cfg.autorestart && exit_code != 0 => {
               match proc.last_start {
                 Some(last_start) => {
-                  let elapsed_time =
-                    Instant::now().duration_since(last_start);
+                  let elapsed_time = Instant::now().duration_since(last_start);
                   elapsed_time.as_secs_f64() > RESTART_THRESHOLD_SECONDS
                 }
                 None => true,

--- a/src/mprocs/app.rs
+++ b/src/mprocs/app.rs
@@ -193,15 +193,26 @@ impl App {
           modal.render(grid);
         }
 
-        for client_handle in &mut self.clients {
+        let mut dead_clients: Vec<usize> = Vec::new();
+        for (idx, client_handle) in self.clients.iter_mut().enumerate() {
           let mut out = String::new();
           client_handle.differ.diff(&mut out, grid).log_ignore();
-          client_handle
+          if client_handle
             .sender
             .send(SrvToClt::Print(out))
             .await
-            .unwrap();
-          client_handle.sender.send(SrvToClt::Flush).await.unwrap();
+            .is_err()
+            || client_handle
+              .sender
+              .send(SrvToClt::Flush)
+              .await
+              .is_err()
+          {
+            dead_clients.push(idx);
+          }
+        }
+        for idx in dead_clients.into_iter().rev() {
+          self.clients.swap_remove(idx);
         }
       }
 


### PR DESCRIPTION
The server calls `.unwrap()` on channel sends when pushing rendered output
to clients. If a client disconnects between renders (e.g. the terminal
window is closed), the send fails and the server panics, taking down all
other connected clients with it.

Replace the unwraps with error handling: if either the `Print` or `Flush`
send fails, mark the client as dead and remove it after the render loop.
Remaining clients are unaffected.