### PR TITLE
Fix dependency start gating

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,8 @@
 
 /release/
 
+# Editor
+/.vscode/
+
 # Cargo
 /target

--- a/src/kernel/kernel.rs
+++ b/src/kernel/kernel.rs
@@ -82,6 +82,7 @@ impl Kernel {
       task,
       stop_on_quit: def.stop_on_quit,
       status: def.status,
+      pending_start: false,
       deps: HashMap::new(),
       path: def.path,
       vt: def.vt,
@@ -150,15 +151,15 @@ impl Kernel {
           if let Some(task) = self.tasks.get_mut(&task_id) {
             match cmd {
               TaskCmd::Start => {
-                let all_deps_ready = task
-                  .deps
-                  .iter()
-                  .all(|(_, dep)| dep.status == TaskStatus::Running);
-                if all_deps_ready {
+                if Self::all_deps_ready(task) {
+                  task.pending_start = false;
                   task.task.handle_cmd(cmd, &mut fx);
+                } else if task.status != TaskStatus::Running {
+                  task.pending_start = true;
                 }
               }
               _ => {
+                task.pending_start = false;
                 task.task.handle_cmd(cmd, &mut fx);
               }
             }
@@ -284,31 +285,21 @@ impl Kernel {
           task.status = TaskStatus::Running;
         }
 
-        if started {
-          if let Some(rev_deps) = self.rev_deps.get(&task_id) {
-            for rev_dep_id in rev_deps {
-              if let Some(rev_dep) = self.tasks.get_mut(rev_dep_id) {
-                let mut all_deps_ready = true;
-                for (dep_id, dep) in &mut rev_dep.deps {
-                  if *dep_id == task_id {
-                    dep.status = TaskStatus::Running;
-                  }
-                  if dep.status != TaskStatus::Running {
-                    all_deps_ready = false;
-                  }
-                }
-                if all_deps_ready {
-                  self
-                    .sender
-                    .send(KernelMessage {
-                      from: TaskId(0),
-                      command: KernelCommand::TaskCmd(
-                        *rev_dep_id,
-                        TaskCmd::Start,
-                      ),
-                    })
-                    .log_ignore();
-                }
+        if started && let Some(rev_deps) = self.rev_deps.get(&task_id).cloned()
+        {
+          for rev_dep_id in rev_deps {
+            if let Some(rev_dep) = self.tasks.get_mut(&rev_dep_id) {
+              if let Some(dep) = rev_dep.deps.get_mut(&task_id) {
+                dep.status = TaskStatus::Running;
+              }
+              if rev_dep.pending_start && Self::all_deps_ready(rev_dep) {
+                self
+                  .sender
+                  .send(KernelMessage {
+                    from: TaskId(0),
+                    command: KernelCommand::TaskCmd(rev_dep_id, TaskCmd::Start),
+                  })
+                  .log_ignore();
               }
             }
           }
@@ -320,6 +311,17 @@ impl Kernel {
       TaskEffect::Stopped(exit_code) => {
         if let Some(task) = self.tasks.get_mut(&task_id) {
           task.status = TaskStatus::Exited(exit_code);
+          task.pending_start = false;
+        }
+
+        if let Some(rev_deps) = self.rev_deps.get(&task_id).cloned() {
+          for rev_dep_id in rev_deps {
+            if let Some(rev_dep) = self.tasks.get_mut(&rev_dep_id)
+              && let Some(dep) = rev_dep.deps.get_mut(&task_id)
+            {
+              dep.status = TaskStatus::Exited(exit_code);
+            }
+          }
         }
         self.notify_listeners(task_id, TaskNotify::Stopped(exit_code));
       }
@@ -380,6 +382,13 @@ impl Kernel {
       }
     }
     true
+  }
+
+  fn all_deps_ready(task: &TaskHandle) -> bool {
+    task
+      .deps
+      .values()
+      .all(|dep| dep.status == TaskStatus::Running)
   }
 }
 
@@ -488,4 +497,228 @@ fn render_screen_ansi(screen: &crate::term::screen::Screen) -> String {
   }
 
   out
+}
+
+#[cfg(test)]
+mod tests {
+  use std::time::Duration;
+
+  use tokio::sync::mpsc::{
+    UnboundedReceiver, error::TryRecvError, unbounded_channel,
+  };
+
+  use super::*;
+
+  #[derive(Debug, PartialEq)]
+  enum RecordedCmd {
+    Start,
+    Stop,
+    Kill,
+  }
+
+  struct RecordingTask {
+    tx: UnboundedSender<RecordedCmd>,
+  }
+
+  impl Task for RecordingTask {
+    fn handle_cmd(&mut self, cmd: TaskCmd, fx: &mut Effects) {
+      match cmd {
+        TaskCmd::Start => {
+          self.tx.send(RecordedCmd::Start).unwrap();
+          fx.started();
+        }
+        TaskCmd::Stop => {
+          self.tx.send(RecordedCmd::Stop).unwrap();
+          fx.stopped(0);
+        }
+        TaskCmd::Kill => {
+          self.tx.send(RecordedCmd::Kill).unwrap();
+          fx.stopped(137);
+        }
+        TaskCmd::Msg(_) => {}
+      }
+    }
+  }
+
+  fn recording_task() -> (
+    UnboundedReceiver<RecordedCmd>,
+    impl FnOnce(TaskContext) -> Box<dyn Task> + 'static,
+  ) {
+    let (tx, rx) = unbounded_channel();
+    (rx, move |_| Box::new(RecordingTask { tx }))
+  }
+
+  async fn recv_cmd(rx: &mut UnboundedReceiver<RecordedCmd>) -> RecordedCmd {
+    tokio::time::timeout(Duration::from_secs(1), rx.recv())
+      .await
+      .expect("timed out waiting for task command")
+      .expect("task command channel closed")
+  }
+
+  async fn flush_kernel(pc: &TaskContext) {
+    let (response_tx, response_rx) = tokio::sync::oneshot::channel();
+    pc.send(KernelCommand::Query(
+      KernelQuery::ListTasks(None),
+      response_tx,
+    ));
+    tokio::time::timeout(Duration::from_secs(1), response_rx)
+      .await
+      .expect("timed out waiting for kernel query response")
+      .expect("kernel query response channel closed");
+  }
+
+  fn assert_no_cmd(rx: &mut UnboundedReceiver<RecordedCmd>) {
+    match rx.try_recv() {
+      Ok(cmd) => panic!("unexpected task command: {cmd:?}"),
+      Err(TryRecvError::Disconnected) => panic!("task command channel closed"),
+      Err(TryRecvError::Empty) => {}
+    }
+  }
+
+  #[tokio::test]
+  async fn repro_dependency_start_does_not_start_unrequested_dependent() {
+    let mut kernel = Kernel::new();
+    let pc = kernel.context();
+
+    let (mut provider_rx, provider_task) = recording_task();
+    let provider_id = kernel.register_task(TaskDef::default(), provider_task);
+
+    let (mut dependent_rx, dependent_task) = recording_task();
+    kernel.register_task(
+      TaskDef {
+        deps: vec![provider_id],
+        ..Default::default()
+      },
+      dependent_task,
+    );
+
+    let kernel_task = tokio::spawn(kernel.run());
+
+    pc.send(KernelCommand::TaskCmd(provider_id, TaskCmd::Start));
+
+    assert_eq!(recv_cmd(&mut provider_rx).await, RecordedCmd::Start);
+    flush_kernel(&pc).await;
+    assert_no_cmd(&mut dependent_rx);
+
+    pc.send(KernelCommand::Quit);
+    tokio::time::timeout(Duration::from_secs(1), kernel_task)
+      .await
+      .expect("timed out waiting for kernel to quit")
+      .unwrap();
+  }
+
+  #[tokio::test]
+  async fn repro_stopped_dependency_blocks_later_dependent_start() {
+    let mut kernel = Kernel::new();
+    let pc = kernel.context();
+
+    let (mut provider_rx, provider_task) = recording_task();
+    let provider_id = kernel.register_task(
+      TaskDef {
+        status: TaskStatus::Running,
+        ..Default::default()
+      },
+      provider_task,
+    );
+
+    let (mut dependent_rx, dependent_task) = recording_task();
+    let dependent_id = kernel.register_task(
+      TaskDef {
+        deps: vec![provider_id],
+        ..Default::default()
+      },
+      dependent_task,
+    );
+
+    let kernel_task = tokio::spawn(kernel.run());
+
+    pc.send(KernelCommand::TaskCmd(provider_id, TaskCmd::Stop));
+
+    assert_eq!(recv_cmd(&mut provider_rx).await, RecordedCmd::Stop);
+
+    pc.send(KernelCommand::TaskCmd(dependent_id, TaskCmd::Start));
+
+    flush_kernel(&pc).await;
+    assert_no_cmd(&mut dependent_rx);
+
+    pc.send(KernelCommand::Quit);
+    tokio::time::timeout(Duration::from_secs(1), kernel_task)
+      .await
+      .expect("timed out waiting for kernel to quit")
+      .unwrap();
+  }
+
+  #[tokio::test]
+  async fn requested_dependent_starts_when_dependency_becomes_running() {
+    let mut kernel = Kernel::new();
+    let pc = kernel.context();
+
+    let (mut provider_rx, provider_task) = recording_task();
+    let provider_id = kernel.register_task(TaskDef::default(), provider_task);
+
+    let (mut dependent_rx, dependent_task) = recording_task();
+    let dependent_id = kernel.register_task(
+      TaskDef {
+        deps: vec![provider_id],
+        ..Default::default()
+      },
+      dependent_task,
+    );
+
+    let kernel_task = tokio::spawn(kernel.run());
+
+    pc.send(KernelCommand::TaskCmd(dependent_id, TaskCmd::Start));
+    flush_kernel(&pc).await;
+    assert_no_cmd(&mut dependent_rx);
+
+    pc.send(KernelCommand::TaskCmd(provider_id, TaskCmd::Start));
+
+    assert_eq!(recv_cmd(&mut provider_rx).await, RecordedCmd::Start);
+    assert_eq!(recv_cmd(&mut dependent_rx).await, RecordedCmd::Start);
+
+    pc.send(KernelCommand::Quit);
+    tokio::time::timeout(Duration::from_secs(1), kernel_task)
+      .await
+      .expect("timed out waiting for kernel to quit")
+      .unwrap();
+  }
+
+  #[tokio::test]
+  async fn stop_cancels_pending_dependent_start() {
+    let mut kernel = Kernel::new();
+    let pc = kernel.context();
+
+    let (mut provider_rx, provider_task) = recording_task();
+    let provider_id = kernel.register_task(TaskDef::default(), provider_task);
+
+    let (mut dependent_rx, dependent_task) = recording_task();
+    let dependent_id = kernel.register_task(
+      TaskDef {
+        deps: vec![provider_id],
+        ..Default::default()
+      },
+      dependent_task,
+    );
+
+    let kernel_task = tokio::spawn(kernel.run());
+
+    pc.send(KernelCommand::TaskCmd(dependent_id, TaskCmd::Start));
+    flush_kernel(&pc).await;
+    assert_no_cmd(&mut dependent_rx);
+
+    pc.send(KernelCommand::TaskCmd(dependent_id, TaskCmd::Stop));
+    assert_eq!(recv_cmd(&mut dependent_rx).await, RecordedCmd::Stop);
+
+    pc.send(KernelCommand::TaskCmd(provider_id, TaskCmd::Start));
+
+    assert_eq!(recv_cmd(&mut provider_rx).await, RecordedCmd::Start);
+    flush_kernel(&pc).await;
+    assert_no_cmd(&mut dependent_rx);
+
+    pc.send(KernelCommand::Quit);
+    tokio::time::timeout(Duration::from_secs(1), kernel_task)
+      .await
+      .expect("timed out waiting for kernel to quit")
+      .unwrap();
+  }
 }

--- a/src/kernel/kernel.rs
+++ b/src/kernel/kernel.rs
@@ -158,8 +158,11 @@ impl Kernel {
                   task.pending_start = true;
                 }
               }
-              _ => {
+              TaskCmd::Stop | TaskCmd::Kill => {
                 task.pending_start = false;
+                task.task.handle_cmd(cmd, &mut fx);
+              }
+              TaskCmd::Msg(_) => {
                 task.task.handle_cmd(cmd, &mut fx);
               }
             }
@@ -668,6 +671,45 @@ mod tests {
     let kernel_task = tokio::spawn(kernel.run());
 
     pc.send(KernelCommand::TaskCmd(dependent_id, TaskCmd::Start));
+    flush_kernel(&pc).await;
+    assert_no_cmd(&mut dependent_rx);
+
+    pc.send(KernelCommand::TaskCmd(provider_id, TaskCmd::Start));
+
+    assert_eq!(recv_cmd(&mut provider_rx).await, RecordedCmd::Start);
+    assert_eq!(recv_cmd(&mut dependent_rx).await, RecordedCmd::Start);
+
+    pc.send(KernelCommand::Quit);
+    tokio::time::timeout(Duration::from_secs(1), kernel_task)
+      .await
+      .expect("timed out waiting for kernel to quit")
+      .unwrap();
+  }
+
+  #[tokio::test]
+  async fn pending_dependent_start_survives_task_msg() {
+    let mut kernel = Kernel::new();
+    let pc = kernel.context();
+
+    let (mut provider_rx, provider_task) = recording_task();
+    let provider_id = kernel.register_task(TaskDef::default(), provider_task);
+
+    let (mut dependent_rx, dependent_task) = recording_task();
+    let dependent_id = kernel.register_task(
+      TaskDef {
+        deps: vec![provider_id],
+        ..Default::default()
+      },
+      dependent_task,
+    );
+
+    let kernel_task = tokio::spawn(kernel.run());
+
+    pc.send(KernelCommand::TaskCmd(dependent_id, TaskCmd::Start));
+    flush_kernel(&pc).await;
+    assert_no_cmd(&mut dependent_rx);
+
+    pc.send(KernelCommand::TaskCmd(dependent_id, TaskCmd::msg(())));
     flush_kernel(&pc).await;
     assert_no_cmd(&mut dependent_rx);
 

--- a/src/kernel/task.rs
+++ b/src/kernel/task.rs
@@ -118,6 +118,7 @@ pub struct TaskHandle {
 
   pub stop_on_quit: bool,
   pub status: TaskStatus,
+  pub pending_start: bool,
 
   pub deps: HashMap<TaskId, DepInfo>,
 

--- a/src/mprocs/app.rs
+++ b/src/mprocs/app.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, fmt::Debug, time::Instant};
+use std::{collections::HashMap, time::Instant};
 
 use anyhow::bail;
 use futures::{future::FutureExt, select};
@@ -274,13 +274,7 @@ impl App {
       .iter()
       .map(|_| self.pc.alloc_id())
       .collect();
-    let name_to_id: HashMap<&str, TaskId> = self
-      .config
-      .procs
-      .iter()
-      .zip(task_ids.iter())
-      .map(|(p, id)| (p.name.as_str(), *id))
-      .collect();
+    let deps_by_proc = resolve_proc_deps(&self.config.procs, &task_ids)?;
 
     let mut procs = self
       .config
@@ -288,15 +282,14 @@ impl App {
       .iter()
       .enumerate()
       .map(|(i, proc_cfg)| {
-        let mut deps = Vec::new();
-        for dep_name in &proc_cfg.deps {
-          if let Some(dep_id) = name_to_id.get(dep_name.as_str()) {
-            deps.push(*dep_id);
-          } else {
-            // TODO: Show error.
-          }
-        }
-        launch_proc(&self.pc, proc_cfg.clone(), task_ids[i], deps, None, size)
+        launch_proc(
+          &self.pc,
+          proc_cfg.clone(),
+          task_ids[i],
+          deps_by_proc[i].clone(),
+          None,
+          size,
+        )
       })
       .collect::<Vec<_>>();
 
@@ -1121,6 +1114,119 @@ impl App {
   }
 }
 
+fn resolve_proc_deps(
+  proc_configs: &[ProcConfig],
+  task_ids: &[TaskId],
+) -> anyhow::Result<Vec<Vec<TaskId>>> {
+  if proc_configs.len() != task_ids.len() {
+    bail!("Internal error: proc and task id counts differ.");
+  }
+
+  let mut name_to_id = HashMap::new();
+  let mut name_to_index = HashMap::new();
+  for (index, (proc_config, task_id)) in
+    proc_configs.iter().zip(task_ids.iter()).enumerate()
+  {
+    if name_to_id
+      .insert(proc_config.name.as_str(), *task_id)
+      .is_some()
+    {
+      bail!("Duplicate process name '{}'.", proc_config.name);
+    }
+    name_to_index.insert(proc_config.name.as_str(), index);
+  }
+
+  let mut deps_by_proc = Vec::with_capacity(proc_configs.len());
+  let mut dep_indexes_by_proc = Vec::with_capacity(proc_configs.len());
+  for proc_config in proc_configs {
+    let mut deps = Vec::with_capacity(proc_config.deps.len());
+    let mut dep_indexes = Vec::with_capacity(proc_config.deps.len());
+    for dep_name in &proc_config.deps {
+      let Some(dep_id) = name_to_id.get(dep_name.as_str()) else {
+        bail!(
+          "Process '{}' depends on unknown process '{}'.",
+          proc_config.name,
+          dep_name
+        );
+      };
+      let Some(dep_index) = name_to_index.get(dep_name.as_str()) else {
+        bail!(
+          "Process '{}' depends on unknown process '{}'.",
+          proc_config.name,
+          dep_name
+        );
+      };
+      deps.push(*dep_id);
+      dep_indexes.push(*dep_index);
+    }
+    deps_by_proc.push(deps);
+    dep_indexes_by_proc.push(dep_indexes);
+  }
+
+  validate_proc_dep_cycles(proc_configs, &dep_indexes_by_proc)?;
+
+  Ok(deps_by_proc)
+}
+
+#[derive(Clone, Copy, PartialEq)]
+enum VisitState {
+  Unvisited,
+  Visiting,
+  Visited,
+}
+
+fn validate_proc_dep_cycles(
+  proc_configs: &[ProcConfig],
+  deps_by_proc: &[Vec<usize>],
+) -> anyhow::Result<()> {
+  let mut states = vec![VisitState::Unvisited; proc_configs.len()];
+  let mut stack = Vec::new();
+
+  for index in 0..proc_configs.len() {
+    visit_proc_deps(
+      index,
+      proc_configs,
+      deps_by_proc,
+      &mut states,
+      &mut stack,
+    )?;
+  }
+
+  Ok(())
+}
+
+fn visit_proc_deps(
+  index: usize,
+  proc_configs: &[ProcConfig],
+  deps_by_proc: &[Vec<usize>],
+  states: &mut [VisitState],
+  stack: &mut Vec<usize>,
+) -> anyhow::Result<()> {
+  match states[index] {
+    VisitState::Visited => return Ok(()),
+    VisitState::Visiting => {
+      let cycle_start = stack.iter().position(|&i| i == index).unwrap_or(0);
+      let mut cycle = stack[cycle_start..]
+        .iter()
+        .map(|&i| proc_configs[i].name.as_str())
+        .collect::<Vec<_>>();
+      cycle.push(proc_configs[index].name.as_str());
+      bail!("Process dependency cycle detected: {}.", cycle.join(" -> "));
+    }
+    VisitState::Unvisited => {}
+  }
+
+  states[index] = VisitState::Visiting;
+  stack.push(index);
+  for dep_index in &deps_by_proc[index] {
+    visit_proc_deps(*dep_index, proc_configs, deps_by_proc, states, stack)?;
+  }
+  stack.pop();
+  states[index] = VisitState::Visited;
+
+  Ok(())
+}
+
 pub fn create_app_task(
   config: Config,
   keymap: Keymap,
@@ -1186,4 +1292,74 @@ pub async fn server_main(
   app.run().await?;
 
   Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  fn proc_config(name: &str, deps: &[&str]) -> ProcConfig {
+    ProcConfig {
+      name: name.to_string(),
+      cmd: CmdConfig::Shell {
+        shell: "true".to_string(),
+      },
+      cwd: None,
+      env: None,
+      autostart: false,
+      autorestart: false,
+      stop: StopSignal::default(),
+      deps: deps.iter().map(|dep| dep.to_string()).collect(),
+      mouse_scroll_speed: 1,
+      scrollback_len: 100,
+      log: None,
+    }
+  }
+
+  #[test]
+  fn resolve_proc_deps_maps_names_to_task_ids() {
+    let proc_configs = vec![
+      proc_config("db", &[]),
+      proc_config("api", &["db"]),
+      proc_config("web", &["api", "db"]),
+    ];
+    let task_ids = vec![TaskId(1), TaskId(2), TaskId(3)];
+
+    let deps = resolve_proc_deps(&proc_configs, &task_ids).unwrap();
+
+    assert_eq!(
+      deps,
+      vec![vec![], vec![TaskId(1)], vec![TaskId(2), TaskId(1)]]
+    );
+  }
+
+  #[test]
+  fn resolve_proc_deps_rejects_unknown_dependency() {
+    let proc_configs = vec![proc_config("api", &["db"])];
+    let task_ids = vec![TaskId(1)];
+
+    let err = resolve_proc_deps(&proc_configs, &task_ids).unwrap_err();
+
+    assert_eq!(
+      err.to_string(),
+      "Process 'api' depends on unknown process 'db'."
+    );
+  }
+
+  #[test]
+  fn resolve_proc_deps_rejects_dependency_cycles() {
+    let proc_configs = vec![
+      proc_config("api", &["worker"]),
+      proc_config("worker", &["db"]),
+      proc_config("db", &["api"]),
+    ];
+    let task_ids = vec![TaskId(1), TaskId(2), TaskId(3)];
+
+    let err = resolve_proc_deps(&proc_configs, &task_ids).unwrap_err();
+
+    assert_eq!(
+      err.to_string(),
+      "Process dependency cycle detected: api -> worker -> db -> api."
+    );
+  }
 }

--- a/src/mprocs/proc/proc.rs
+++ b/src/mprocs/proc/proc.rs
@@ -15,17 +15,17 @@ use crate::mprocs::config::ProcConfig;
 use crate::mprocs::proc_log_config::LogConfig;
 use crate::process::process::Process as _;
 use crate::process::process_spec::ProcessSpec;
-use crate::term::encode::{encode_key, encode_mouse_event, KeyCodeEncodeModes};
+use crate::term::encode::{KeyCodeEncodeModes, encode_key, encode_mouse_event};
 use crate::term::grid::Rect;
 use crate::term::key::Key;
 use crate::term::mouse::{MouseEvent, MouseEventKind};
 use crate::term::{MouseProtocolMode, Parser};
 
+use super::Size;
+use super::StopSignal;
 use super::inst::Inst;
 use super::msg::{ProcEvent, ProcMsg};
 use super::view::ProcView;
-use super::Size;
-use super::StopSignal;
 
 pub struct Proc {
   pub id: TaskId,
@@ -57,8 +57,11 @@ pub fn launch_proc(
   path: Option<TaskPath>,
   size: Rect,
 ) -> ProcView {
-  let vt = SharedVt::new(Parser::new(size.height, size.width, cfg.scrollback_len));
-  let cfg_ = cfg.clone();
+  let vt =
+    SharedVt::new(Parser::new(size.height, size.width, cfg.scrollback_len));
+  let autostart = cfg.autostart;
+  let mut cfg_ = cfg.clone();
+  cfg_.autostart = false;
   let task_vt = vt.clone();
   let child_id = parent_ks.spawn_async_with_id(
     task_id,
@@ -75,6 +78,9 @@ pub fn launch_proc(
       proc_main_loop(ks, task_id, &cfg, size, task_vt, cmd_receiver).await;
     },
   );
+  if autostart {
+    parent_ks.send(KernelCommand::TaskCmd(child_id, TaskCmd::Start));
+  }
 
   ProcView::new(child_id, cfg, vt)
 }
@@ -313,9 +319,7 @@ impl Proc {
     }
   }
 
-  pub fn lock_vt(
-    &self,
-  ) -> Option<std::sync::RwLockReadGuard<'_, Parser>> {
+  pub fn lock_vt(&self) -> Option<std::sync::RwLockReadGuard<'_, Parser>> {
     self.vt.read().ok()
   }
 
@@ -551,5 +555,174 @@ impl Proc {
         *rendered = true;
       }
     }
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use std::{
+    path::Path,
+    time::{Duration, Instant, SystemTime, UNIX_EPOCH},
+  };
+
+  use tokio::sync::mpsc::{UnboundedReceiver, unbounded_channel};
+
+  use super::*;
+  use crate::{
+    kernel::{
+      kernel::Kernel,
+      task::{Effects, Task},
+    },
+    mprocs::config::CmdConfig,
+  };
+
+  #[derive(Debug, PartialEq)]
+  enum RecordedCmd {
+    Start,
+    Stop,
+  }
+
+  struct RecordingTask {
+    tx: tokio::sync::mpsc::UnboundedSender<RecordedCmd>,
+  }
+
+  impl Task for RecordingTask {
+    fn handle_cmd(&mut self, cmd: TaskCmd, fx: &mut Effects) {
+      match cmd {
+        TaskCmd::Start => {
+          self.tx.send(RecordedCmd::Start).unwrap();
+          fx.started();
+        }
+        TaskCmd::Stop | TaskCmd::Kill => {
+          self.tx.send(RecordedCmd::Stop).unwrap();
+          fx.stopped(0);
+        }
+        TaskCmd::Msg(_) => {}
+      }
+    }
+  }
+
+  fn recording_task() -> (
+    UnboundedReceiver<RecordedCmd>,
+    impl FnOnce(TaskContext) -> Box<dyn Task> + 'static,
+  ) {
+    let (tx, rx) = unbounded_channel();
+    (rx, move |_| Box::new(RecordingTask { tx }))
+  }
+
+  async fn flush_kernel(pc: &TaskContext) {
+    let (response_tx, response_rx) = tokio::sync::oneshot::channel();
+    pc.send(KernelCommand::Query(
+      crate::kernel::kernel_message::KernelQuery::ListTasks(None),
+      response_tx,
+    ));
+    tokio::time::timeout(Duration::from_secs(1), response_rx)
+      .await
+      .expect("timed out waiting for kernel query response")
+      .expect("kernel query response channel closed");
+  }
+
+  async fn recv_cmd(rx: &mut UnboundedReceiver<RecordedCmd>) -> RecordedCmd {
+    tokio::time::timeout(Duration::from_secs(1), rx.recv())
+      .await
+      .expect("timed out waiting for task command")
+      .expect("task command channel closed")
+  }
+
+  async fn assert_path_absent_for(path: &Path, duration: Duration) {
+    let deadline = Instant::now() + duration;
+    while Instant::now() < deadline {
+      assert!(
+        !path.exists(),
+        "path unexpectedly exists: {}",
+        path.display()
+      );
+      tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+  }
+
+  async fn wait_for_path(path: &Path) {
+    let deadline = Instant::now() + Duration::from_secs(2);
+    while Instant::now() < deadline {
+      if path.exists() {
+        return;
+      }
+      tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    panic!("timed out waiting for path: {}", path.display());
+  }
+
+  #[cfg(not(windows))]
+  #[tokio::test]
+  async fn autostart_proc_waits_for_dependencies() {
+    let mut temp_dir = std::env::temp_dir();
+    let nanos = SystemTime::now()
+      .duration_since(UNIX_EPOCH)
+      .unwrap()
+      .as_nanos();
+    temp_dir.push(format!(
+      "mprocs_autostart_deps_{}_{}",
+      std::process::id(),
+      nanos
+    ));
+    std::fs::create_dir_all(&temp_dir).unwrap();
+    let marker_path = temp_dir.join("started");
+
+    let mut kernel = Kernel::new();
+    let pc = kernel.context();
+
+    let (mut provider_rx, provider_task) = recording_task();
+    let provider_id = kernel.register_task(TaskDef::default(), provider_task);
+
+    let proc_config = ProcConfig {
+      name: "dependent".to_string(),
+      cmd: CmdConfig::Shell {
+        shell: format!("printf started > {}", marker_path.display()),
+      },
+      cwd: None,
+      env: None,
+      autostart: true,
+      autorestart: false,
+      stop: StopSignal::SIGKILL,
+      deps: Vec::new(),
+      mouse_scroll_speed: 1,
+      scrollback_len: 100,
+      log: None,
+    };
+
+    let proc_view = launch_proc(
+      &pc,
+      proc_config,
+      pc.alloc_id(),
+      vec![provider_id],
+      None,
+      Rect {
+        x: 0,
+        y: 0,
+        width: 80,
+        height: 24,
+      },
+    );
+
+    let kernel_task = tokio::spawn(kernel.run());
+
+    flush_kernel(&pc).await;
+    assert_path_absent_for(&marker_path, Duration::from_millis(100)).await;
+
+    pc.send(KernelCommand::TaskCmd(provider_id, TaskCmd::Start));
+    assert_eq!(recv_cmd(&mut provider_rx).await, RecordedCmd::Start);
+
+    wait_for_path(&marker_path).await;
+
+    pc.send(KernelCommand::RemoveTask(proc_view.id()));
+    flush_kernel(&pc).await;
+
+    pc.send(KernelCommand::Quit);
+    tokio::time::timeout(Duration::from_secs(2), kernel_task)
+      .await
+      .expect("timed out waiting for kernel to quit")
+      .unwrap();
+
+    let _ = std::fs::remove_dir_all(temp_dir);
   }
 }

--- a/src/term/screen.rs
+++ b/src/term/screen.rs
@@ -1,4 +1,4 @@
-use std::fmt::Debug;
+use std::{fmt::Debug, str};
 
 use super::{
   attrs::Attrs,

--- a/src/term_driver/input_parser.rs
+++ b/src/term_driver/input_parser.rs
@@ -1,4 +1,5 @@
 use anyhow::{Context, anyhow, bail};
+use std::str;
 
 use crate::term::{
   key::{


### PR DESCRIPTION
Related to #158. This PR fixes several issues in the existing dependency start-gating behaviour:

- queue dependent start requests until all dependencies are running
- avoid auto-starting dependents that were never explicitly requested
- clear pending dependent starts on stop/kill
- update dependent dependency state when a provider exits
- route proc autostart through the dependency-aware kernel start path
- validate proc dependencies at config load time:
  - unknown dependency names
  - dependency cycles
  - duplicate proc names

This also adds focussed regression coverage for the dependency scheduler behaviour.

## Motivation

The existing dependency implementation had enough structure to express simple `depends` relationships, but start behaviour was inconsistent:

- autostarted procs could bypass dependency gating
- dependents could be started incorrectly or fail to start after dependencies became ready
- stopped dependencies were not consistently reflected in reverse dependency state
- invalid dependency config was accepted until runtime behaviour became ambiguous

This PR makes the current dependency model deterministic before building larger readiness/check semantics on top of it.