### PR TITLE
Fix TUI freeze on ghostty caused by lossy Key IPC serialization (#213)

### DIFF
--- a/src/ipc/receiver.rs
+++ b/src/ipc/receiver.rs
@@ -34,38 +34,33 @@ impl<T: DeserializeOwned> tokio_util::codec::Decoder for MsgDecoder<T> {
     &mut self,
     src: &mut BytesMut,
   ) -> Result<Option<Self::Item>, Self::Error> {
-    if let DecoderState::Header = self.state {
-      let len = if src.len() >= 4 {
-        src.get_u32() as usize
-      } else {
-        return Ok(None);
+    loop {
+      let len = match self.state {
+        DecoderState::Header => {
+          if src.len() < 4 {
+            return Ok(None);
+          }
+          let len = src.get_u32() as usize;
+          self.state = DecoderState::Data(len);
+          len
+        }
+        DecoderState::Data(len) => len,
       };
-      self.state = DecoderState::Data(len);
-    }
-    let len = match self.state {
-      DecoderState::Header => {
-        let len = if src.len() >= 4 {
-          src.get_u32() as usize
-        } else {
-          return Ok(None);
-        };
-        self.state = DecoderState::Data(len);
-        len
-      }
-      DecoderState::Data(len) => len,
-    };
 
-    if src.len() >= len {
-      let msg: T = bincode::deserialize(&src[..len])?;
-      if src.len() == len {
-        src.clear();
-      } else {
-        src.advance(len);
+      if src.len() < len {
+        return Ok(None);
       }
+
+      let frame = src.split_to(len);
       self.state = DecoderState::Header;
-      Ok(Some(msg))
-    } else {
-      Ok(None)
+
+      match bincode::deserialize::<T>(&frame) {
+        Ok(msg) => return Ok(Some(msg)),
+        Err(err) => {
+          log::warn!("ipc: skipping undecodable frame ({len} bytes): {err}");
+          continue;
+        }
+      }
     }
   }
 }
@@ -90,5 +85,33 @@ impl<T: DeserializeOwned + Send + 'static> MsgReceiver<T> {
 impl<T: DeserializeOwned> MsgReceiver<T> {
   pub async fn recv(&mut self) -> Option<Result<T, bincode::Error>> {
     self.reader.next().await
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use bytes::{BufMut, BytesMut};
+  use tokio_util::codec::Decoder;
+
+  use super::MsgDecoder;
+
+  fn frame(payload: &[u8]) -> BytesMut {
+    let mut b = BytesMut::new();
+    b.put_u32(payload.len() as u32);
+    b.extend_from_slice(payload);
+    b
+  }
+
+  #[test]
+  fn decode_skips_undecodable_frame() {
+    let mut decoder = MsgDecoder::<bool>::new();
+    let mut buf = BytesMut::new();
+    buf.unsplit(frame(&bincode::serialize(&true).unwrap())); // good
+    buf.unsplit(frame(&[0x05])); // bad: not a valid bool
+    buf.unsplit(frame(&bincode::serialize(&false).unwrap())); // good
+
+    assert_eq!(decoder.decode(&mut buf).unwrap(), Some(true));
+    assert_eq!(decoder.decode(&mut buf).unwrap(), Some(false));
+    assert_eq!(decoder.decode(&mut buf).unwrap(), None);
   }
 }

--- a/src/mprocs/event.rs
+++ b/src/mprocs/event.rs
@@ -54,7 +54,10 @@ pub enum AppEvent {
   CopyModeCopy,
   ToggleKeymapWindow,
 
-  SendKey { key: Key },
+  SendKey {
+    #[serde(with = "crate::term::key::key_string")]
+    key: Key,
+  },
 }
 
 impl AppEvent {
@@ -152,6 +155,18 @@ mod tests {
       })
       .unwrap(),
       "c: send-key\nkey: <C-a>\n"
+    );
+  }
+
+  #[test]
+  fn deserialize_send_key() {
+    let ev: AppEvent =
+      serde_yaml::from_str("c: send-key\nkey: <C-a>\n").unwrap();
+    assert_eq!(
+      ev,
+      AppEvent::SendKey {
+        key: Key::parse("<C-a>").unwrap()
+      }
     );
   }
 }

--- a/src/mprocs/proc/mod.rs
+++ b/src/mprocs/proc/mod.rs
@@ -40,7 +40,11 @@ impl StopSignal {
       serde_yaml::Value::Mapping(map) => {
         if map.len() == 1 {
           if let Some(keys) = map.get("send-keys") {
-            let keys: Vec<Key> = serde_yaml::from_value(keys.clone())?;
+            let key_strs: Vec<String> = serde_yaml::from_value(keys.clone())?;
+            let keys = key_strs
+              .iter()
+              .map(|s| Key::parse(s))
+              .collect::<anyhow::Result<Vec<_>>>()?;
             return Ok(Self::SendKeys(keys));
           }
           if let Some(cmd) = map.get("cmd") {

--- a/src/term/key.rs
+++ b/src/term/key.rs
@@ -47,7 +47,7 @@ static SPECIAL_CHARS: phf::Map<char, &str> = phf::phf_map! {
   '-' => "Minus",
 };
 
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct Key {
   pub code: KeyCode,
   pub mods: KeyMods,
@@ -178,27 +178,30 @@ impl ToString for Key {
   }
 }
 
-impl Serialize for Key {
-  fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-  where
-    S: serde::Serializer,
-  {
-    serializer.serialize_str(self.to_string().as_str())
-  }
-}
+pub mod key_string {
+  use serde::{Deserialize, Deserializer, Serializer};
 
-impl<'de> Deserialize<'de> for Key {
-  fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-  where
-    D: serde::Deserializer<'de>,
-  {
+  use super::Key;
+
+  pub fn serialize<S: Serializer>(
+    key: &Key,
+    serializer: S,
+  ) -> Result<S::Ok, S::Error> {
+    serializer.serialize_str(key.to_string().as_str())
+  }
+
+  pub fn deserialize<'de, D: Deserializer<'de>>(
+    deserializer: D,
+  ) -> Result<Key, D::Error> {
     let text = String::deserialize(deserializer)?;
     Key::parse(text.as_str())
       .map_err(|err| serde::de::Error::custom(err.to_string()))
   }
 }
 
-#[derive(Debug, PartialOrd, PartialEq, Eq, Clone, Copy, Hash)]
+#[derive(
+  Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, PartialOrd, Serialize,
+)]
 pub enum KeyCode {
   Backspace,
   Enter,
@@ -230,7 +233,9 @@ pub enum KeyCode {
   Modifier(ModKeyCode),
 }
 
-#[derive(Debug, PartialOrd, PartialEq, Eq, Clone, Copy, Hash)]
+#[derive(
+  Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, PartialOrd, Serialize,
+)]
 pub enum KeyEventKind {
   Press,
   Repeat,
@@ -238,7 +243,9 @@ pub enum KeyEventKind {
 }
 
 bitflags! {
-  #[derive(Debug, PartialOrd, PartialEq, Eq, Clone, Copy, Hash)]
+  #[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, PartialOrd, Serialize,
+  )]
   pub struct KeyEventState: u8 {
     /// The key event origins from the keypad.
     const KEYPAD = 0b0000_0001;
@@ -254,7 +261,9 @@ bitflags! {
   }
 }
 
-#[derive(Debug, PartialOrd, PartialEq, Eq, Clone, Copy, Hash)]
+#[derive(
+  Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, PartialOrd, Serialize,
+)]
 pub enum MediaKeyCode {
   Play,
   Pause,
@@ -272,7 +281,9 @@ pub enum MediaKeyCode {
 }
 
 /// Represents a modifier key (as part of [`KeyCode::Modifier`]).
-#[derive(Debug, PartialOrd, PartialEq, Eq, Clone, Copy, Hash)]
+#[derive(
+  Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, PartialOrd, Serialize,
+)]
 pub enum ModKeyCode {
   LeftShift,
   LeftControl,
@@ -460,5 +471,39 @@ mod tests {
     in_out("<Minus>");
     in_out("<LT>");
     in_out("<GT>");
+  }
+
+  #[test]
+  fn wire_keys_round_trip_losslessly() {
+    let keys = [
+      Key::new(KeyCode::CapsLock, KeyMods::NONE),
+      Key::new(KeyCode::NumLock, KeyMods::NONE),
+      Key::new(KeyCode::Media(MediaKeyCode::PlayPause), KeyMods::NONE),
+      Key::new_with_kind(
+        KeyCode::Modifier(ModKeyCode::LeftSuper),
+        KeyMods::SUPER,
+        KeyEventKind::Press,
+      ),
+      Key::new(KeyCode::F(13), KeyMods::CONTROL),
+      Key::new(KeyCode::Char('我'), KeyMods::NONE),
+    ];
+    for key in keys {
+      let bytes = bincode::serialize(&key).unwrap();
+      let decoded: Key = bincode::deserialize(&bytes)
+        .unwrap_or_else(|e| panic!("decode of {key:?} failed: {e}"));
+      assert_eq!(decoded, key);
+    }
+  }
+
+  #[test]
+  fn key_string_adapter_round_trips_and_is_strict() {
+    #[derive(serde::Deserialize, serde::Serialize, PartialEq, Debug)]
+    struct Wrap(#[serde(with = "super::key_string")] Key);
+
+    let key = Key::parse("<C-a>").unwrap();
+    let yaml = serde_yaml::to_string(&Wrap(key)).unwrap();
+    assert_eq!(yaml, "<C-a>\n");
+    assert_eq!(serde_yaml::from_str::<Wrap>(&yaml).unwrap(), Wrap(key));
+    assert!(serde_yaml::from_str::<Wrap>("<Bogus>").is_err());
   }
 }


### PR DESCRIPTION
## Summary

Fixes the TUI freeze in #213 (ghostty / macOS, "becomes unresponsive after long uptime"). It turns out to be **deterministic** — not a kqueue lost-wakeup, but a lossy key serialization on the in-process IPC wire.

## Root cause

mprocs runs a client/server split in one process, connected by two `tokio::io::simplex` pipes carrying bincode-framed messages. `Key` (`src/term/key.rs`) implements `Serialize`/`Deserialize` via its human-readable string form (`to_string` / `Key::parse`, e.g. `<C-a>`), which is meant for config keybindings — but that form is **lossy and not total**: keys the kitty keyboard protocol reports yet the string form can't represent (`CapsLock`, `NumLock`, modifier presses via `Modifier(_)`, media keys, `F13+`) fail to `parse` on the way back.

The terminal client forwards every non-release key as `CltToSrv::Key`. When one of those keys is sent, the server side's `bincode::deserialize` fails → the framed read yields an error → `client_loop` treats it as a disconnect and emits `ClientDisconnected` → the app drops its only client → `render_needed && clients.len() > 0` becomes permanently false → the screen never repaints and input is never processed, while the process stays alive.

This reproduces on ghostty (which negotiates the kitty protocol via `CSI ?u`, so it emits these extra key events) but not on Apple Terminal — matching the issue. Instrumented logs confirmed the exact sequence: a `CapsLock` press immediately preceded `client_loop … disconnected`, after which only client-side input events appear and rendering stops.

## Fix

1. **Lossless wire serialization** — derive structural `Serialize`/`Deserialize` for `Key` and its component enums (`KeyCode`, `KeyEventKind`, `ModKeyCode`, `MediaKeyCode`, `KeyEventState`) so the IPC wire round-trips every key.
2. **Keep the readable string form for config** — `AppEvent::SendKey` and `StopSignal::SendKeys` (YAML / `--ctl`) still use the `<C-a>` form via a small `key_string` serde adapter; config parsing stays strict.
3. **Defense in depth** — the IPC frame decoder now skips an undecodable frame (with a warning) instead of tearing down the connection, so no single message can freeze the UI again.

## Reproduction

On a terminal with the kitty keyboard protocol (e.g. ghostty): run mprocs and press **CapsLock** (or NumLock / a media key), or switch terminal tabs / split-and-close a window (these send modifier-key events). Before this change the TUI freezes; after it, those keys are handled cleanly.

## Tests

`cargo test --workspace` — 45 passing. New tests:
- `wire_keys_round_trip_losslessly` — CapsLock, media, modifier, F13, wide-char keys round-trip through bincode.
- `key_string_adapter_round_trips_and_is_strict` — YAML `<C-a>` form preserved and strict.
- `deserialize_send_key` — `--ctl` `send-key` still parses.
- `decode_skips_undecodable_frame` — decoder skips a bad frame instead of failing.
